### PR TITLE
Support subpixel scaling and origin for DrawString calls

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+[*.cs]
+indent_style = tab
+indent_size = 2

--- a/samples/FontStashSharp.Samples.DynamicSpriteFont/Game1.cs
+++ b/samples/FontStashSharp.Samples.DynamicSpriteFont/Game1.cs
@@ -45,6 +45,7 @@ namespace SpriteFontPlus.Samples.TtfBaking
 
 		private Texture2D _white;
 		private bool _drawBackground = false;
+		private bool _animatedScaling = false;
 
 		private static readonly Color[] ColoredTextColors = new Color[]
 		{
@@ -182,13 +183,17 @@ namespace SpriteFontPlus.Samples.TtfBaking
 			if (KeyboardUtils.IsPressed(Keys.Enter))
 			{
 				_currentFontSystem.UseKernings = !_currentFontSystem.UseKernings;
+			}
 
+			if (KeyboardUtils.IsPressed(Keys.LeftShift))
+			{
+				_animatedScaling = !_animatedScaling;
 			}
 
 			KeyboardUtils.End();
 		}
 
-		private void DrawString(string text, int y, Color[] glyphColors)
+		private void DrawString(string text, int y, Color[] glyphColors, Vector2 scale)
 		{
 			if (_drawBackground)
 			{
@@ -196,10 +201,10 @@ namespace SpriteFontPlus.Samples.TtfBaking
 				_spriteBatch.Draw(_white, new Rectangle(0, y, (int)size.X, (int)size.Y), Color.Green);
 			}
 
-			_spriteBatch.DrawString(_font, text, new Vector2(0, y), glyphColors);
+			_spriteBatch.DrawString(_font, text, new Vector2(0, y), glyphColors, scale);
 		}
 
-		private void DrawString(string text, int y, Color color)
+		private void DrawString(string text, int y, Color color, Vector2 scale)
 		{
 			if (_drawBackground)
 			{
@@ -207,12 +212,12 @@ namespace SpriteFontPlus.Samples.TtfBaking
 				_spriteBatch.Draw(_white, new Rectangle(0, y, (int)size.X, (int)size.Y), Color.Green);
 			}
 
-			_spriteBatch.DrawString(_font, text, new Vector2(0, y), color);
+			_spriteBatch.DrawString(_font, text, new Vector2(0, y), color, scale);
 		}
 
-		private void DrawString(string text, int y)
+		private void DrawString(string text, int y, Vector2 scale)
 		{
-			DrawString(text, y, Color.White);
+			DrawString(text, y, Color.White, scale);
 		}
 
 		/// <summary>
@@ -232,6 +237,17 @@ namespace SpriteFontPlus.Samples.TtfBaking
 			GraphicsContext.CommandList.SetRenderTargetAndViewport(GraphicsDevice.Presenter.DepthStencilBuffer, GraphicsDevice.Presenter.BackBuffer);
 #endif
 
+			
+			Vector2 scale;
+			if (_animatedScaling)
+			{
+				scale = new Vector2(1 + .25f * (float) Math.Sin(gameTime.TotalGameTime.TotalSeconds * .5f));
+			}
+			else
+			{
+				scale = Vector2.One;
+			}
+
 			// TODO: Add your drawing code here
 #if MONOGAME || FNA
 			_spriteBatch.Begin();
@@ -241,15 +257,15 @@ namespace SpriteFontPlus.Samples.TtfBaking
 
 			// Render some text
 			_font = _currentFontSystem.GetFont(18);
-			DrawString("The quick いろは brown\nfox にほへ jumps over\nt🙌h📦e l👏a👏zy dog adfasoqiw yraldh ald halwdha ldjahw dlawe havbx get872rq", 0);
+			DrawString("The quick いろは brown\nfox にほへ jumps over\nt🙌h📦e l👏a👏zy dog adfasoqiw yraldh ald halwdha ldjahw dlawe havbx get872rq", 0, scale);
 
 			_font = _currentFontSystem.GetFont(30);
-			DrawString("The quick いろは brown\nfox にほへ jumps over\nt🙌h📦e l👏a👏zy dog", 80, Color.Bisque);
+			DrawString("The quick いろは brown\nfox にほへ jumps over\nt🙌h📦e l👏a👏zy dog", 80, Color.Bisque, scale);
 
-			DrawString("Colored Text", 200, ColoredTextColors);
+			DrawString("Colored Text", 200, ColoredTextColors, scale);
 
 			_font = _currentFontSystem.GetFont(26);
-			DrawString("Texture:", 380);
+			DrawString("Texture:", 380, Vector2.One);
 			
 			var texture = _currentFontSystem.EnumerateTextures().First();
 			_spriteBatch.Draw(texture, new Vector2(0, 410), Color.White);

--- a/samples/FontStashSharp.Samples.DynamicSpriteFont/Game1.cs
+++ b/samples/FontStashSharp.Samples.DynamicSpriteFont/Game1.cs
@@ -26,11 +26,22 @@ using SharpDX.Direct3D11;
 namespace SpriteFontPlus.Samples.TtfBaking
 {
 	/// <summary>
+	/// Indicates how text is aligned.
+	/// </summary>
+	public enum Alignment
+	{
+		Left,
+		Center,
+		Right
+	}
+
+	/// <summary>
 	/// This is the main type for your game.
 	/// </summary>
 	public class Game1 : Game
 	{
 		private const int EffectAmount = 1;
+		private const int LineSpacing = 10;
 
 #if !STRIDE
 		private readonly GraphicsDeviceManager _graphics;
@@ -193,31 +204,59 @@ namespace SpriteFontPlus.Samples.TtfBaking
 			KeyboardUtils.End();
 		}
 
-		private void DrawString(string text, int y, Color[] glyphColors, Vector2 scale)
+		private void DrawString(string text, ref Vector2 cursor, Alignment alignment, Color[] glyphColors, Vector2 scale)
 		{
+			Vector2 dimensions = _font.MeasureString(text);
+			Vector2 origin = AlignmentOrigin(alignment, dimensions);
+
 			if (_drawBackground)
 			{
-				var size = _font.MeasureString(text);
-				_spriteBatch.Draw(_white, new Rectangle(0, y, (int)size.X, (int)size.Y), Color.Green);
+				DrawRectangle(cursor, origin, dimensions, scale);
 			}
 
-			_spriteBatch.DrawString(_font, text, new Vector2(0, y), glyphColors, scale);
+			_spriteBatch.DrawString(_font, text, cursor, glyphColors, scale, origin);
+			cursor.Y += dimensions.Y + LineSpacing;
 		}
 
-		private void DrawString(string text, int y, Color color, Vector2 scale)
+		private void DrawString(string text, ref Vector2 cursor, Alignment alignment, Color color, Vector2 scale)
 		{
+			Vector2 dimensions = _font.MeasureString(text);
+			Vector2 origin = AlignmentOrigin(alignment, dimensions);
+
 			if (_drawBackground)
 			{
-				var size = _font.MeasureString(text);
-				_spriteBatch.Draw(_white, new Rectangle(0, y, (int)size.X, (int)size.Y), Color.Green);
+				DrawRectangle(cursor, origin, dimensions, scale);
 			}
 
-			_spriteBatch.DrawString(_font, text, new Vector2(0, y), color, scale);
+			_spriteBatch.DrawString(_font, text, cursor, color, scale, origin);
+			cursor.Y += dimensions.Y + LineSpacing;
 		}
 
-		private void DrawString(string text, int y, Vector2 scale)
+		private void DrawString(string text, ref Vector2 cursor, Alignment alignment, Vector2 scale)
 		{
-			DrawString(text, y, Color.White, scale);
+			DrawString(text, ref cursor, alignment, Color.White, scale);
+		}
+
+		private void DrawRectangle(Vector2 position, Vector2 origin, Vector2 dimensions, Vector2 scale)
+		{
+			Vector2 textureScaler = dimensions / new Vector2(_white.Width, _white.Height) * scale;
+			_spriteBatch.Draw(_white, position - origin * scale, _white.Bounds, Color.Green, 0, Vector2.Zero, textureScaler,
+				SpriteEffects.None, 0);
+		}
+
+		private static Vector2 AlignmentOrigin(Alignment alignment, Vector2 dimensions)
+		{
+			switch (alignment)
+			{
+				case Alignment.Left:
+					return Vector2.Zero;
+				case Alignment.Center:
+					return new Vector2(dimensions.X / 2, 0);
+				case Alignment.Right:
+					return new Vector2(dimensions.X, 0);
+				default:
+					return Vector2.Zero;
+			}
 		}
 
 		/// <summary>
@@ -237,17 +276,10 @@ namespace SpriteFontPlus.Samples.TtfBaking
 			GraphicsContext.CommandList.SetRenderTargetAndViewport(GraphicsDevice.Presenter.DepthStencilBuffer, GraphicsDevice.Presenter.BackBuffer);
 #endif
 
+			Vector2 scale = _animatedScaling
+				? new Vector2(1 + .25f * (float) Math.Sin(gameTime.TotalGameTime.TotalSeconds * .5f))
+				: Vector2.One;
 			
-			Vector2 scale;
-			if (_animatedScaling)
-			{
-				scale = new Vector2(1 + .25f * (float) Math.Sin(gameTime.TotalGameTime.TotalSeconds * .5f));
-			}
-			else
-			{
-				scale = Vector2.One;
-			}
-
 			// TODO: Add your drawing code here
 #if MONOGAME || FNA
 			_spriteBatch.Begin();
@@ -255,20 +287,37 @@ namespace SpriteFontPlus.Samples.TtfBaking
 			_spriteBatch.Begin(GraphicsContext);
 #endif
 
+			Vector2 cursor = Vector2.Zero;
+
 			// Render some text
+
 			_font = _currentFontSystem.GetFont(18);
-			DrawString("The quick いろは brown\nfox にほへ jumps over\nt🙌h📦e l👏a👏zy dog adfasoqiw yraldh ald halwdha ldjahw dlawe havbx get872rq", 0, scale);
+			DrawString("The quick いろは brown\nfox にほへ jumps over\nt🙌h📦e l👏a👏zy dog adfasoqiw yraldh ald halwdha ldjahw dlawe havbx get872rq", ref cursor, Alignment.Left, scale);
 
 			_font = _currentFontSystem.GetFont(30);
-			DrawString("The quick いろは brown\nfox にほへ jumps over\nt🙌h📦e l👏a👏zy dog", 80, Color.Bisque, scale);
+			DrawString("The quick いろは brown\nfox にほへ jumps over\nt🙌h📦e l👏a👏zy dog", ref cursor, Alignment.Left, Color.Bisque, scale);
 
-			DrawString("Colored Text", 200, ColoredTextColors, scale);
+			DrawString("Colored Text", ref cursor, Alignment.Left, ColoredTextColors, scale);
 
+			// Render some scaled text with alignment using origin.
+			
+			Vector2 columnCursor = cursor;
+			DrawString("Left-Justified", ref columnCursor, Alignment.Left, new Vector2(.75f) * scale);
+
+			columnCursor = new Vector2(GraphicsDevice.Viewport.Width/2f, cursor.Y);
+			DrawString("Centered", ref columnCursor, Alignment.Center, new Vector2(1) * scale);
+			
+			columnCursor = new Vector2(GraphicsDevice.Viewport.Width, cursor.Y);
+			DrawString("Right-Justified", ref columnCursor, Alignment.Right, new Vector2(1.5f) * scale);
+
+			cursor = new Vector2(0, columnCursor.Y);
+
+			// Render the atlas texture
 			_font = _currentFontSystem.GetFont(26);
-			DrawString("Texture:", 380, Vector2.One);
+			DrawString("Texture:", ref cursor, Alignment.Left, Vector2.One);
 			
 			var texture = _currentFontSystem.EnumerateTextures().First();
-			_spriteBatch.Draw(texture, new Vector2(0, 410), Color.White);
+			_spriteBatch.Draw(texture, cursor, Color.White);
 
 			_spriteBatch.End();
 

--- a/src/FontStashSharp/DynamicSpriteFont.cs
+++ b/src/FontStashSharp/DynamicSpriteFont.cs
@@ -5,6 +5,7 @@ using System.Text;
 
 #if MONOGAME || FNA
 using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
 #elif STRIDE
 using Stride.Core.Mathematics;
 #else
@@ -157,13 +158,16 @@ namespace FontStashSharp
 				GetQuad(glyph, prevGlyph, scale, ref originX, ref originY, ref q);
 				if (!glyph.IsEmpty)
 				{
-					var destRect = new Rectangle((int)(x + q.X0), (int)(y + q.Y0), (int)(q.X1 - q.X0), (int)(q.Y1 - q.Y0));
 					var sourceRect = new Rectangle((int)q.S0, (int)q.T0, (int)(q.S1 - q.S0), (int)(q.T1 - q.T0));
 
 					batch.Draw(glyph.Atlas.Texture,
-						destRect,
+						new Vector2(x + q.X0, y + q.Y0),
 						sourceRect,
 						color,
+						0,
+						Vector2.Zero,
+						scale,
+						SpriteEffects.None,
 						depth);
 				}
 
@@ -216,13 +220,16 @@ namespace FontStashSharp
 				GetQuad(glyph, prevGlyph, scale, ref originX, ref originY, ref q);
 				if (!glyph.IsEmpty)
 				{
-					var destRect = new Rectangle((int)(x + q.X0), (int)(y + q.Y0), (int)(q.X1 - q.X0), (int)(q.Y1 - q.Y0));
 					var sourceRect = new Rectangle((int)q.S0, (int)q.T0, (int)(q.S1 - q.S0), (int)(q.T1 - q.T0));
 
 					batch.Draw(glyph.Atlas.Texture,
-						destRect,
+						new Vector2(x + q.X0, y + q.Y0),
 						sourceRect,
 						colors[pos],
+						0,
+						Vector2.Zero,
+						scale,
+						SpriteEffects.None,
 						depth);
 				}
 
@@ -295,13 +302,16 @@ namespace FontStashSharp
 				GetQuad(glyph, prevGlyph, scale, ref originX, ref originY, ref q);
 				if (!glyph.IsEmpty)
 				{
-					var destRect = new Rectangle((int)(x + q.X0), (int)(y + q.Y0), (int)(q.X1 - q.X0), (int)(q.Y1 - q.Y0));
 					var sourceRect = new Rectangle((int)q.S0, (int)q.T0, (int)(q.S1 - q.S0), (int)(q.T1 - q.T0));
 
 					batch.Draw(glyph.Atlas.Texture,
-						destRect,
+						new Vector2(x + q.X0, y + q.Y0),
 						sourceRect,
 						color,
+						0,
+						Vector2.Zero,
+						scale,
+						SpriteEffects.None,
 						depth);
 				}
 
@@ -354,13 +364,16 @@ namespace FontStashSharp
 				GetQuad(glyph, prevGlyph, scale, ref originX, ref originY, ref q);
 				if (!glyph.IsEmpty)
 				{
-					var destRect = new Rectangle((int)(x + q.X0), (int)(y + q.Y0), (int)(q.X1 - q.X0), (int)(q.Y1 - q.Y0));
 					var sourceRect = new Rectangle((int)q.S0, (int)q.T0, (int)(q.S1 - q.S0), (int)(q.T1 - q.T0));
 
 					batch.Draw(glyph.Atlas.Texture,
-						destRect,
+						new Vector2(x + q.X0, y + q.Y0),
 						sourceRect,
 						glyphColors[pos],
+						0,
+						Vector2.Zero,
+						scale,
+						SpriteEffects.None,
 						depth);
 				}
 

--- a/src/FontStashSharp/DynamicSpriteFont.cs
+++ b/src/FontStashSharp/DynamicSpriteFont.cs
@@ -18,6 +18,7 @@ namespace FontStashSharp
 	public partial class DynamicSpriteFont
 	{
 		internal static readonly Vector2 DefaultScale = new Vector2(1.0f, 1.0f);
+		internal static readonly Vector2 DefaultOrigin = Vector2.Zero;
 		private readonly Int32Map<FontGlyph> _glyphs = new Int32Map<FontGlyph>();
 
 		public FontSystem FontSystem { get; private set; }
@@ -124,7 +125,8 @@ namespace FontStashSharp
 			}
 		}
 
-		public float DrawText(IFontStashRenderer batch, float x, float y, string str, Color color, Vector2 scale, float depth = 0.0f)
+		public float DrawText(IFontStashRenderer batch, float x, float y, string str, Color color, Vector2 scale,
+			Vector2 origin, float depth = 0.0f)
 		{
 			if (string.IsNullOrEmpty(str)) return 0.0f;
 
@@ -165,7 +167,7 @@ namespace FontStashSharp
 						sourceRect,
 						color,
 						0,
-						Vector2.Zero,
+						origin,
 						scale,
 						SpriteEffects.None,
 						depth);
@@ -177,12 +179,17 @@ namespace FontStashSharp
 			return x;
 		}
 
+		public float DrawText(IFontStashRenderer batch, float x, float y, string str, Color color, Vector2 scale, float depth = 0.0f)
+		{
+			return DrawText(batch, x, y, str, color, scale, DefaultOrigin, depth);
+		}
+
 		public float DrawText(IFontStashRenderer batch, float x, float y, string str, Color color, float depth = 0.0f)
 		{
 			return DrawText(batch, x, y, str, color, DefaultScale, depth);
 		}
 
-		public float DrawText(IFontStashRenderer batch, float x, float y, string str, Color[] colors, Vector2 scale, float depth = 0.0f)
+		public float DrawText(IFontStashRenderer batch, float x, float y, string str, Color[] colors, Vector2 scale, Vector2 origin, float depth = 0.0f)
 		{
 			if (string.IsNullOrEmpty(str)) return 0.0f;
 
@@ -227,7 +234,7 @@ namespace FontStashSharp
 						sourceRect,
 						colors[pos],
 						0,
-						Vector2.Zero,
+						origin,
 						scale,
 						SpriteEffects.None,
 						depth);
@@ -240,6 +247,12 @@ namespace FontStashSharp
 			return x;
 		}
 
+		public float DrawText(IFontStashRenderer batch, float x, float y, string str, Color[] colors, Vector2 scale,
+			float depth = 0.0f)
+		{
+			return DrawText(batch, x, y, str, colors, scale, DefaultOrigin, depth);
+		}
+		
 		public float DrawText(IFontStashRenderer batch, float x, float y, string str, Color[] colors, float depth = 0.0f)
 		{
 			return DrawText(batch, x, y, str, colors, DefaultScale, depth);
@@ -267,7 +280,8 @@ namespace FontStashSharp
 			}
 		}
 
-		public float DrawText(IFontStashRenderer batch, float x, float y, StringBuilder str, Color color, Vector2 scale, float depth = 0.0f)
+		public float DrawText(IFontStashRenderer batch, float x, float y, StringBuilder str, Color color, Vector2 scale,
+			Vector2 origin, float depth = 0.0f)
 		{
 			if (str == null || str.Length == 0) return 0.0f;
 
@@ -309,7 +323,7 @@ namespace FontStashSharp
 						sourceRect,
 						color,
 						0,
-						Vector2.Zero,
+						origin,
 						scale,
 						SpriteEffects.None,
 						depth);
@@ -321,12 +335,18 @@ namespace FontStashSharp
 			return x;
 		}
 
-		public float DrawText(IFontStashRenderer batch, float x, float y, StringBuilder str, Color color, float depth = 0.0f)
+		public float DrawText(IFontStashRenderer batch, float x, float y, StringBuilder str, Color color, Vector2 scale, float depth = 0.0f)
 		{
-			return DrawText(batch, x, y, str, color, DefaultScale, depth);
+			return DrawText(batch, x, y, str, color, scale, DefaultOrigin, depth);
 		}
 
-		public float DrawText(IFontStashRenderer batch, float x, float y, StringBuilder str, Color[] glyphColors, Vector2 scale, float depth = 0.0f)
+		public float DrawText(IFontStashRenderer batch, float x, float y, StringBuilder str, Color color, float depth = 0.0f)
+		{
+			return DrawText(batch, x, y, str, color, DefaultScale, DefaultOrigin, depth);
+		}
+
+		public float DrawText(IFontStashRenderer batch, float x, float y, StringBuilder str, Color[] glyphColors,
+			Vector2 scale, Vector2 origin, float depth = 0.0f)
 		{
 			if (str == null || str.Length == 0) return 0.0f;
 
@@ -371,7 +391,7 @@ namespace FontStashSharp
 						sourceRect,
 						glyphColors[pos],
 						0,
-						Vector2.Zero,
+						origin,
 						scale,
 						SpriteEffects.None,
 						depth);
@@ -384,9 +404,15 @@ namespace FontStashSharp
 			return x;
 		}
 
+		public float DrawText(IFontStashRenderer batch, float x, float y, StringBuilder str, Color[] colors, Vector2 scale,
+			float depth = 0.0f)
+		{
+			return DrawText(batch, x, y, str, colors, scale, DefaultOrigin, depth);
+		}		
+		
 		public float DrawText(IFontStashRenderer batch, float x, float y, StringBuilder str, Color[] colors, float depth = 0.0f)
 		{
-			return DrawText(batch, x, y, str, colors, DefaultScale, depth);
+			return DrawText(batch, x, y, str, colors, DefaultScale, DefaultOrigin, depth);
 		}
 
 		public float TextBounds(float x, float y, string str, ref Bounds bounds, Vector2 scale)

--- a/src/FontStashSharp/Interfaces/IFontStashRenderer.cs
+++ b/src/FontStashSharp/Interfaces/IFontStashRenderer.cs
@@ -1,5 +1,6 @@
 ﻿#if MONOGAME || FNA
 using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
 #elif STRIDE
 using Stride.Core.Mathematics;
 #else
@@ -11,5 +12,8 @@ namespace FontStashSharp.Interfaces
 	public interface IFontStashRenderer
 	{
 		void Draw(ITexture2D texture, Rectangle dest, Rectangle source, Color color, float depth);
+
+		void Draw(ITexture2D texture, Vector2 position, Rectangle? sourceRectangle, Color color, float rotation,
+			Vector2 origin, Vector2 scale, SpriteEffects effects, float depth);
 	}
 }

--- a/src/XNA/DynamicSpriteFont.XNA.cs
+++ b/src/XNA/DynamicSpriteFont.XNA.cs
@@ -12,11 +12,16 @@ namespace FontStashSharp
 {
 	partial class DynamicSpriteFont
 	{
-		public float DrawText(SpriteBatch batch, string text, Vector2 pos, Color color, Vector2 scale, float depth = 0.0f)
+		public float DrawText(SpriteBatch batch, string text, Vector2 pos, Color color, Vector2 scale, Vector2 origin, float depth = 0.0f)
 		{
 			var renderer = SpriteBatchRenderer.Instance;
 			renderer.Batch = batch;
-			return DrawText(renderer, pos.X, pos.Y, text, color, scale, depth);
+			return DrawText(renderer, pos.X, pos.Y, text, color, scale, origin, depth);
+		}
+
+		public float DrawText(SpriteBatch batch, string text, Vector2 pos, Color color, Vector2 scale, float depth = 0.0f)
+		{
+			return DrawText(batch, text, pos, color, scale, DefaultOrigin, depth);
 		}
 
 		public float DrawText(SpriteBatch batch, string text, Vector2 pos, Color color, float depth = 0.0f)
@@ -24,12 +29,17 @@ namespace FontStashSharp
 			return DrawText(batch, text, pos, color, DefaultScale, depth);
 		}
 
-		public float DrawText(SpriteBatch batch, string text, Vector2 pos, Color[] colors, Vector2 scale, float depth = 0.0f)
+		public float DrawText(SpriteBatch batch, string text, Vector2 pos, Color[] colors, Vector2 scale, Vector2 origin, float depth = 0.0f)
 		{
 			var renderer = SpriteBatchRenderer.Instance;
 			renderer.Batch = batch;
 
-			return DrawText(renderer, pos.X, pos.Y, text, colors, scale, depth);
+			return DrawText(renderer, pos.X, pos.Y, text, colors, scale, origin, depth);
+		}
+
+		public float DrawText(SpriteBatch batch, string text, Vector2 pos, Color[] colors, Vector2 scale, float depth = 0.0f)
+		{
+			return DrawText(batch, text, pos, colors, scale, DefaultOrigin, depth);
 		}
 
 		public float DrawText(SpriteBatch batch, string text, Vector2 pos, Color[] colors, float depth = 0.0f)
@@ -37,12 +47,17 @@ namespace FontStashSharp
 			return DrawText(batch, text, pos, colors, DefaultScale, depth);
 		}
 
-		public float DrawText(SpriteBatch batch, StringBuilder text, Vector2 pos, Color color, Vector2 scale, float depth = 0.0f)
+		public float DrawText(SpriteBatch batch, StringBuilder text, Vector2 pos, Color color, Vector2 scale, Vector2 origin, float depth = 0.0f)
 		{
 			var renderer = SpriteBatchRenderer.Instance;
 			renderer.Batch = batch;
 
-			return DrawText(renderer, pos.X, pos.Y, text, color, scale, depth);
+			return DrawText(renderer, pos.X, pos.Y, text, color, scale, origin, depth);
+		}
+
+		public float DrawText(SpriteBatch batch, StringBuilder text, Vector2 pos, Color color, Vector2 scale, float depth = 0.0f)
+		{
+			return DrawText(batch, text, pos, color, scale, DefaultOrigin, depth);
 		}
 
 		public float DrawText(SpriteBatch batch, StringBuilder text, Vector2 pos, Color color, float depth = 0.0f)
@@ -50,12 +65,17 @@ namespace FontStashSharp
 			return DrawText(batch, text, pos, color, DefaultScale, depth);
 		}
 
-		public float DrawText(SpriteBatch batch, StringBuilder text, Vector2 pos, Color[] colors, Vector2 scale, float depth = 0.0f)
+		public float DrawText(SpriteBatch batch, StringBuilder text, Vector2 pos, Color[] colors, Vector2 scale, Vector2 origin, float depth = 0.0f)
 		{
 			var renderer = SpriteBatchRenderer.Instance;
 			renderer.Batch = batch;
 
-			return DrawText(renderer, pos.X, pos.Y, text, colors, scale, depth);
+			return DrawText(renderer, pos.X, pos.Y, text, colors, scale, origin, depth);
+		}
+
+		public float DrawText(SpriteBatch batch, StringBuilder text, Vector2 pos, Color[] colors, Vector2 scale, float depth = 0.0f)
+		{
+			return DrawText(batch, text, pos, colors, scale, DefaultOrigin, depth);
 		}
 
 		public float DrawText(SpriteBatch batch, StringBuilder text, Vector2 pos, Color[] colors, float depth = 0.0f)

--- a/src/XNA/SpriteBatchExtensions.cs
+++ b/src/XNA/SpriteBatchExtensions.cs
@@ -12,6 +12,11 @@ namespace FontStashSharp
 {
 	public static class SpriteBatchExtensions
 	{
+		public static float DrawString(this SpriteBatch batch, DynamicSpriteFont font, string text, Vector2 pos, Color color, Vector2 scale, Vector2 origin, float depth = 0.0f)
+		{
+			return font.DrawText(batch, text, pos, color, scale, origin, depth);
+		}
+
 		public static float DrawString(this SpriteBatch batch, DynamicSpriteFont font, string text, Vector2 pos, Color color, Vector2 scale, float depth = 0.0f)
 		{
 			return font.DrawText(batch, text, pos, color, scale, depth);
@@ -20,6 +25,11 @@ namespace FontStashSharp
 		public static float DrawString(this SpriteBatch batch, DynamicSpriteFont font, string text, Vector2 pos, Color color, float depth = 0.0f)
 		{
 			return font.DrawText(batch, text, pos, color, depth);
+		}
+
+		public static float DrawString(this SpriteBatch batch, DynamicSpriteFont font, string text, Vector2 pos, Color[] colors, Vector2 scale, Vector2 origin, float depth = 0.0f)
+		{
+			return font.DrawText(batch, text, pos, colors, scale, origin, depth);
 		}
 
 		public static float DrawString(this SpriteBatch batch, DynamicSpriteFont font, string text, Vector2 pos, Color[] colors, Vector2 scale, float depth = 0.0f)
@@ -32,6 +42,11 @@ namespace FontStashSharp
 			return font.DrawText(batch, text, pos, colors, depth);
 		}
 
+		public static float DrawString(this SpriteBatch batch, DynamicSpriteFont font, StringBuilder text, Vector2 pos, Color color, Vector2 scale, Vector2 origin, float depth = 0.0f)
+		{
+			return font.DrawText(batch, text, pos, color, scale, origin, depth);
+		}
+
 		public static float DrawString(this SpriteBatch batch, DynamicSpriteFont font, StringBuilder text, Vector2 pos, Color color, Vector2 scale, float depth = 0.0f)
 		{
 			return font.DrawText(batch, text, pos, color, scale, depth);
@@ -40,6 +55,11 @@ namespace FontStashSharp
 		public static float DrawString(this SpriteBatch batch, DynamicSpriteFont font, StringBuilder text, Vector2 pos, Color color, float depth = 0.0f)
 		{
 			return font.DrawText(batch, text, pos, color, depth);
+		}
+
+		public static float DrawString(this SpriteBatch batch, DynamicSpriteFont font, StringBuilder text, Vector2 pos, Color[] colors, Vector2 scale, Vector2 origin, float depth = 0.0f)
+		{
+			return font.DrawText(batch, text, pos, colors, scale, origin, depth);
 		}
 
 		public static float DrawString(this SpriteBatch batch, DynamicSpriteFont font, StringBuilder text, Vector2 pos, Color[] colors, Vector2 scale, float depth = 0.0f)

--- a/src/XNA/SpriteBatchRenderer.cs
+++ b/src/XNA/SpriteBatchRenderer.cs
@@ -90,7 +90,7 @@ namespace FontStashSharp
 				origin,
 				scale,
 				SpriteEffects.None,
-        ImageOrientation.AsIs,
+				ImageOrientation.AsIs,
 				depth);
 #endif
 		}

--- a/src/XNA/SpriteBatchRenderer.cs
+++ b/src/XNA/SpriteBatchRenderer.cs
@@ -65,5 +65,34 @@ namespace FontStashSharp
 				depth);
 #endif
 		}
+
+		public void Draw(ITexture2D texture, Vector2 position, Rectangle? sourceRectangle, Color color, float rotation,
+			Vector2 origin, Vector2 scale, SpriteEffects effects, float depth)
+		{
+			var textureWrapper = (Texture2DWrapper)texture;
+
+#if MONOGAME || FNA
+			_batch.Draw(textureWrapper.Texture,
+				position,
+				sourceRectangle,
+				color,
+				rotation,
+				origin,
+				scale,
+				SpriteEffects.None,
+				depth);
+#elif STRIDE
+			_batch.Draw(textureWrapper.Texture,
+				position,
+				sourceRectangle,
+				color,
+				rotation,
+				origin,
+				scale,
+				SpriteEffects.None,
+        ImageOrientation.AsIs,
+				depth);
+#endif
+		}
 	}
 }


### PR DESCRIPTION
This pull request adds support for two things:

- Subpixel scaling allows smooth scaling (similar to SpriteFont) whithout quantization errors.
- Support for origin which is useful for alignment among other things.
- Adjusted the sample to show/test the features (press Left-Shift to animate the scaling).