### PR TITLE
Render internally with a higher font size to reduce blurred text due to UI scaling

### DIFF
--- a/src/FontStashSharp/DynamicSpriteFont.cs
+++ b/src/FontStashSharp/DynamicSpriteFont.cs
@@ -121,6 +121,7 @@ namespace FontStashSharp
 			for (int i = 0; i < str.Length; i += char.IsSurrogatePair(str, i) ? 2 : 1)
 			{
 				var codepoint = char.ConvertToUtf32(str, i);
+
 				var glyph = GetDynamicGlyph(codepoint, withoutBitmap);
 				if (glyph == null)
 				{
@@ -143,6 +144,7 @@ namespace FontStashSharp
 			for (int i = 0; i < str.Length; i += StringBuilderIsSurrogatePair(str, i) ? 2 : 1)
 			{
 				var codepoint = StringBuilderConvertToUtf32(str, i);
+
 				var glyph = GetDynamicGlyph(codepoint, withoutBitmap);
 				if (glyph == null)
 				{

--- a/src/FontStashSharp/DynamicSpriteFont.cs
+++ b/src/FontStashSharp/DynamicSpriteFont.cs
@@ -104,7 +104,7 @@ namespace FontStashSharp
 			return GetDynamicGlyph(codepoint, withoutBitmap);
 	}
 
-	protected override void PreDraw(string str, out float ascent, out float lineHeight)
+	protected override void PreDraw(string str, out float ascent, out float lineHeight, bool isForMeasurement)
 		{
 			// Determine ascent and lineHeight from first character
 			ascent = 0;
@@ -120,13 +120,13 @@ namespace FontStashSharp
 				}
 
 				float descent;
-				glyph.Font.GetMetricsForSize(RenderFontSize, out ascent, out descent, out lineHeight);
+				glyph.Font.GetMetricsForSize(isForMeasurement ? FontSize : RenderFontSize, out ascent, out descent, out lineHeight);
 				lineHeight += FontSystem.LineSpacing;
 				break;
 			}
 		}
 
-		protected override void PreDraw(StringBuilder str, out float ascent, out float lineHeight)
+		protected override void PreDraw(StringBuilder str, out float ascent, out float lineHeight, bool isForMeasurement)
 		{
 			// Determine ascent and lineHeight from first character
 			ascent = 0;
@@ -142,7 +142,7 @@ namespace FontStashSharp
 				}
 
 				float descent;
-				glyph.Font.GetMetricsForSize(RenderFontSize, out ascent, out descent, out lineHeight);
+				glyph.Font.GetMetricsForSize(isForMeasurement ? FontSize : RenderFontSize, out ascent, out descent, out lineHeight);
 				break;
 			}
 		}

--- a/src/FontStashSharp/DynamicSpriteFont.cs
+++ b/src/FontStashSharp/DynamicSpriteFont.cs
@@ -43,7 +43,6 @@ namespace FontStashSharp
 			if (g == null)
 			{
 				Glyphs[codepoint] = null;
-				
 				return null;
 			}
 
@@ -122,11 +121,9 @@ namespace FontStashSharp
 
 				float descent;
 				glyph.Font.GetMetricsForSize(RenderFontSize, out ascent, out descent, out lineHeight);
-				lineHeight += FontSystem.LineSpacing;// * ((float)FontSize / (float)RenderFontSize);
-				//ascent *= ((float)FontSize / (float)RenderFontSize);
+				lineHeight += FontSystem.LineSpacing;
 				break;
 			}
-	  //ascent *= ((float)FontSize / (float)RenderFontSize);
 	}
 
 		protected override void PreDraw(StringBuilder str, out float ascent, out float lineHeight)

--- a/src/FontStashSharp/DynamicSpriteFont.cs
+++ b/src/FontStashSharp/DynamicSpriteFont.cs
@@ -16,7 +16,8 @@ namespace FontStashSharp
 {
 	public partial class DynamicSpriteFont: SpriteFontBase
 	{
-		internal readonly Int32Map<DynamicFontGlyph>[] Glyphs = new Int32Map<DynamicFontGlyph>[] { new Int32Map<DynamicFontGlyph>(), new Int32Map<DynamicFontGlyph>() };
+		internal readonly Int32Map<DynamicFontGlyph> Glyphs = new Int32Map<DynamicFontGlyph>();
+		internal readonly Int32Map<DynamicFontGlyph> GlyphsWithoutBitmap = new Int32Map<DynamicFontGlyph>();
 
 		public FontSystem FontSystem { get; private set; }
 
@@ -28,38 +29,38 @@ namespace FontStashSharp
 			}
 
 			FontSystem = system;
+			RenderFontSizeMultiplicator = FontSystem.FontResolutionFactor;
 		}
 
-		internal int GetGlyphMapIndexFor(bool isForMeasurement)
+		internal Int32Map<DynamicFontGlyph> GetGlyphMapFor(bool isForMeasurement)
 		{
-			return isForMeasurement ? 0 : 1;
+			return isForMeasurement ? GlyphsWithoutBitmap : Glyphs;
 		}
 
-		private DynamicFontGlyph GetGlyphWithoutBitmap(int codepoint, bool isForMeasurement)
+		private DynamicFontGlyph GetGlyphWithoutBitmap(int codepoint, bool withoutBitmap)
 		{
 			DynamicFontGlyph glyph = null;
-			var index = GetGlyphMapIndexFor(isForMeasurement);
-			if (Glyphs[index].TryGetValue(codepoint, out glyph))
+			var glyphs = GetGlyphMapFor(withoutBitmap);
+			if (glyphs.TryGetValue(codepoint, out glyph))
 			{
 				return glyph;
 			}
 
-			IDynamicFontSource font;
+			IFontSource font;
 			var g = FontSystem.GetCodepointIndex(codepoint, out font);
 			if (g == null)
 			{
-				Glyphs[codepoint] = null;
+				glyphs[codepoint] = null;
 				return null;
 			}
 
 			int advance = 0, x0 = 0, y0 = 0, x1 = 0, y1 = 0;
-			var fontSize = FontSize * (isForMeasurement ? 1 : RenderFontSizeMultiplicator);
+			var fontSize = (int) (FontSize * (withoutBitmap ? 1 : FontSystem.FontResolutionFactor));
 			font.GetGlyphMetrics(g.Value, fontSize, out advance, out x0, out y0, out x1, out y1);
 
 			var pad = Math.Max(DynamicFontGlyph.PadFromBlur(FontSystem.BlurAmount), DynamicFontGlyph.PadFromBlur(FontSystem.StrokeAmount));
-			var kernelWidth = 2;
-			var gw = x1 - x0 + pad * 2 + kernelWidth;
-			var gh = y1 - y0 + pad * 2 + kernelWidth;
+			var gw = (x1 - x0) + pad * 2 + FontSystem.KernelWidth;
+			var gh = (y1 - y0) + pad * 2 + FontSystem.KernelHeight;
 			var offset = DynamicFontGlyph.PadFromBlur(FontSystem.BlurAmount);
 
 			glyph = new DynamicFontGlyph
@@ -69,20 +70,19 @@ namespace FontStashSharp
 				Size = fontSize,
 				Font = font,
 				Bounds = new Rectangle(0, 0, gw, gh),
-				KernelWidth = (uint)kernelWidth,
 				XAdvance = advance,
 				XOffset = x0 - offset,
 				YOffset = y0 - offset
 			};
 
-			Glyphs[index][codepoint] = glyph;
+			glyphs[codepoint] = glyph;
 
 			return glyph;
 		}
 
-		private DynamicFontGlyph GetGlyphInternal(int codepoint, bool withoutBitmap, bool isForMeasurement)
+		private DynamicFontGlyph GetGlyphInternal(int codepoint, bool withoutBitmap)
 		{
-			var glyph = GetGlyphWithoutBitmap(codepoint, isForMeasurement);
+			var glyph = GetGlyphWithoutBitmap(codepoint, withoutBitmap);
 			if (glyph == null)
 			{
 				return null;
@@ -96,32 +96,32 @@ namespace FontStashSharp
 			return glyph;
 		}
 
-		private DynamicFontGlyph GetDynamicGlyph(int codepoint, bool withoutBitmap, bool isForMeasurement)
+		private DynamicFontGlyph GetDynamicGlyph(int codepoint, bool withoutBitmap)
 		{
-			var result = GetGlyphInternal(codepoint, withoutBitmap, isForMeasurement);
+			var result = GetGlyphInternal(codepoint, withoutBitmap);
 			if (result == null && FontSystem.DefaultCharacter != null)
 			{
-				result = GetGlyphInternal(FontSystem.DefaultCharacter.Value, withoutBitmap, isForMeasurement);
+				result = GetGlyphInternal(FontSystem.DefaultCharacter.Value, withoutBitmap);
 			}
 
 			return result;
 		}
 
-	protected internal override FontGlyph GetGlyph(int codepoint, bool withoutBitmap, bool isForMeasurement)
+	protected internal override FontGlyph GetGlyph(int codepoint, bool withoutBitmap)
 	{
-			return GetDynamicGlyph(codepoint, withoutBitmap, isForMeasurement);
+			return GetDynamicGlyph(codepoint, withoutBitmap);
 	}
 
-	protected override void PreDraw(string str, out float ascent, out float lineHeight, bool isForMeasurement)
+	protected override void PreDraw(string str, out float ascent, out float lineHeight, bool withoutBitmap)
 		{
 			// Determine ascent and lineHeight from first character
 			ascent = 0;
 			lineHeight = 0;
-			var fontSize = isForMeasurement ? FontSize : FontSize * RenderFontSizeMultiplicator;
+			var fontSize = (int)(withoutBitmap ? FontSize : FontSize * RenderFontSizeMultiplicator);
 			for (int i = 0; i < str.Length; i += char.IsSurrogatePair(str, i) ? 2 : 1)
 			{
 				var codepoint = char.ConvertToUtf32(str, i);
-				var glyph = GetDynamicGlyph(codepoint, true, isForMeasurement);
+				var glyph = GetDynamicGlyph(codepoint, withoutBitmap);
 				if (glyph == null)
 				{
 					continue;
@@ -134,16 +134,16 @@ namespace FontStashSharp
 			}
 		}
 
-		protected override void PreDraw(StringBuilder str, out float ascent, out float lineHeight, bool isForMeasurement)
+		protected override void PreDraw(StringBuilder str, out float ascent, out float lineHeight, bool withoutBitmap)
 		{
 			// Determine ascent and lineHeight from first character
 			ascent = 0;
 			lineHeight = 0;
-			var fontSize = isForMeasurement ? FontSize : FontSize * RenderFontSizeMultiplicator;
+			var fontSize = (int)(withoutBitmap ? FontSize : FontSize * RenderFontSizeMultiplicator);
 			for (int i = 0; i < str.Length; i += StringBuilderIsSurrogatePair(str, i) ? 2 : 1)
 			{
 				var codepoint = StringBuilderConvertToUtf32(str, i);
-				var glyph = GetDynamicGlyph(codepoint, true, isForMeasurement);
+				var glyph = GetDynamicGlyph(codepoint, withoutBitmap);
 				if (glyph == null)
 				{
 					continue;

--- a/src/FontStashSharp/DynamicSpriteFont.cs
+++ b/src/FontStashSharp/DynamicSpriteFont.cs
@@ -47,7 +47,7 @@ namespace FontStashSharp
 			}
 
 			int advance = 0, x0 = 0, y0 = 0, x1 = 0, y1 = 0;
-			var fontSize = RenderFontSize;
+			var fontSize = FontSize * RenderFontSizeMultiplicator;
 			font.GetGlyphMetrics(g.Value, fontSize, out advance, out x0, out y0, out x1, out y1);
 
 			var pad = Math.Max(DynamicFontGlyph.PadFromBlur(FontSystem.BlurAmount), DynamicFontGlyph.PadFromBlur(FontSystem.StrokeAmount));
@@ -109,6 +109,7 @@ namespace FontStashSharp
 			// Determine ascent and lineHeight from first character
 			ascent = 0;
 			lineHeight = 0;
+			var fontSize = isForMeasurement ? FontSize : FontSize * RenderFontSizeMultiplicator;
 			for (int i = 0; i < str.Length; i += char.IsSurrogatePair(str, i) ? 2 : 1)
 			{
 				var codepoint = char.ConvertToUtf32(str, i);
@@ -120,7 +121,7 @@ namespace FontStashSharp
 				}
 
 				float descent;
-				glyph.Font.GetMetricsForSize(isForMeasurement ? FontSize : RenderFontSize, out ascent, out descent, out lineHeight);
+				glyph.Font.GetMetricsForSize(fontSize, out ascent, out descent, out lineHeight);
 				lineHeight += FontSystem.LineSpacing;
 				break;
 			}
@@ -131,6 +132,7 @@ namespace FontStashSharp
 			// Determine ascent and lineHeight from first character
 			ascent = 0;
 			lineHeight = 0;
+			var fontSize = isForMeasurement ? FontSize : FontSize * RenderFontSizeMultiplicator;
 			for (int i = 0; i < str.Length; i += StringBuilderIsSurrogatePair(str, i) ? 2 : 1)
 			{
 				var codepoint = StringBuilderConvertToUtf32(str, i);
@@ -142,7 +144,7 @@ namespace FontStashSharp
 				}
 
 				float descent;
-				glyph.Font.GetMetricsForSize(isForMeasurement ? FontSize : RenderFontSize, out ascent, out descent, out lineHeight);
+				glyph.Font.GetMetricsForSize(fontSize, out ascent, out descent, out lineHeight);
 				break;
 			}
 		}

--- a/src/FontStashSharp/DynamicSpriteFont.cs
+++ b/src/FontStashSharp/DynamicSpriteFont.cs
@@ -44,7 +44,7 @@ namespace FontStashSharp
 				return glyph;
 			}
 
-			IFontSource font;
+			IDynamicFontSource font;
 			var g = FontSystem.GetCodepointIndex(codepoint, out font);
 			if (g == null)
 			{
@@ -57,8 +57,9 @@ namespace FontStashSharp
 			font.GetGlyphMetrics(g.Value, fontSize, out advance, out x0, out y0, out x1, out y1);
 
 			var pad = Math.Max(DynamicFontGlyph.PadFromBlur(FontSystem.BlurAmount), DynamicFontGlyph.PadFromBlur(FontSystem.StrokeAmount));
-			var gw = x1 - x0 + pad * 2;
-			var gh = y1 - y0 + pad * 2;
+			var kernelWidth = 2;
+			var gw = x1 - x0 + pad * 2 + kernelWidth;
+			var gh = y1 - y0 + pad * 2 + kernelWidth;
 			var offset = DynamicFontGlyph.PadFromBlur(FontSystem.BlurAmount);
 
 			glyph = new DynamicFontGlyph
@@ -68,6 +69,7 @@ namespace FontStashSharp
 				Size = fontSize,
 				Font = font,
 				Bounds = new Rectangle(0, 0, gw, gh),
+				KernelWidth = (uint)kernelWidth,
 				XAdvance = advance,
 				XOffset = x0 - offset,
 				YOffset = y0 - offset

--- a/src/FontStashSharp/DynamicSpriteFont.cs
+++ b/src/FontStashSharp/DynamicSpriteFont.cs
@@ -124,7 +124,7 @@ namespace FontStashSharp
 				lineHeight += FontSystem.LineSpacing;
 				break;
 			}
-	}
+		}
 
 		protected override void PreDraw(StringBuilder str, out float ascent, out float lineHeight)
 		{

--- a/src/FontStashSharp/FontAtlas.cs
+++ b/src/FontStashSharp/FontAtlas.cs
@@ -199,7 +199,8 @@ namespace FontStashSharp
 				pad + pad * glyph.Bounds.Width,
 				glyph.Bounds.Width - pad * 2,
 				glyph.Bounds.Height - pad * 2,
-				glyph.Bounds.Width);
+				glyph.Bounds.Width,
+				glyph.KernelWidth);
 
 			if (strokeAmount > 0)
 			{

--- a/src/FontStashSharp/FontAtlas.cs
+++ b/src/FontStashSharp/FontAtlas.cs
@@ -168,7 +168,7 @@ namespace FontStashSharp
 		}
 
 #if MONOGAME || FNA || STRIDE
-		public void RenderGlyph(GraphicsDevice graphicsDevice, DynamicFontGlyph glyph, int blurAmount, int strokeAmount, bool premultiplyAlpha)
+		public void RenderGlyph(GraphicsDevice graphicsDevice, DynamicFontGlyph glyph, int blurAmount, int strokeAmount, bool premultiplyAlpha, int kernelWidth, int kernelHeight)
 #else
 		public void RenderGlyph(ITexture2DManager textureManager, DynamicFontGlyph glyph, int blurAmount, int strokeAmount, bool premultiplyAlpha)
 #endif
@@ -200,7 +200,8 @@ namespace FontStashSharp
 				glyph.Bounds.Width - pad * 2,
 				glyph.Bounds.Height - pad * 2,
 				glyph.Bounds.Width,
-				glyph.KernelWidth);
+				kernelWidth,
+				kernelHeight);
 
 			if (strokeAmount > 0)
 			{

--- a/src/FontStashSharp/FontGlyph.cs
+++ b/src/FontStashSharp/FontGlyph.cs
@@ -35,7 +35,8 @@ namespace FontStashSharp
 	public class DynamicFontGlyph: FontGlyph
 	{
 		public int Size;
-		public IFontSource Font;
+		public IDynamicFontSource Font;
+		public uint KernelWidth;
 
 		public static int PadFromBlur(int blur)
 		{

--- a/src/FontStashSharp/FontGlyph.cs
+++ b/src/FontStashSharp/FontGlyph.cs
@@ -35,8 +35,7 @@ namespace FontStashSharp
 	public class DynamicFontGlyph: FontGlyph
 	{
 		public int Size;
-		public IDynamicFontSource Font;
-		public uint KernelWidth;
+		public IFontSource Font;
 
 		public static int PadFromBlur(int blur)
 		{

--- a/src/FontStashSharp/FontSystem.cs
+++ b/src/FontStashSharp/FontSystem.cs
@@ -205,7 +205,28 @@ namespace FontStashSharp
 			return g;
 		}
 
-		internal void RenderGlyphOnAtlas(DynamicFontGlyph glyph)
+		internal int? GetCodepointIndex(int codepoint, out IDynamicFontSource font)
+		{
+			font = null;
+
+			var g = default(int?);
+			foreach (var f in _fontSources)
+			{
+				if(f is IDynamicFontSource df)
+				{
+					g = df.GetGlyphId(codepoint);
+					if (g != null)
+					{
+						font = df;
+						break;
+					}
+				}
+			}
+
+			return g;
+		}
+
+		internal void RenderGlyphOnAtlas(DynamicFontGlyph glyph, bool prefilter)
 		{
 			var currentAtlas = CurrentAtlas;
 			int gx = 0, gy = 0;

--- a/src/FontStashSharp/FontSystem.cs
+++ b/src/FontStashSharp/FontSystem.cs
@@ -42,6 +42,9 @@ namespace FontStashSharp
 		public int CharacterSpacing = 0;
 		public int LineSpacing = 0;
 
+		public int KernelWidth { get; protected set; }
+		public int KernelHeight { get; protected set; }
+
 		public FontAtlas CurrentAtlas
 		{
 			get
@@ -58,12 +61,14 @@ namespace FontStashSharp
 
 		public List<FontAtlas> Atlases { get; } = new List<FontAtlas>();
 
+		public float FontResolutionFactor { get; protected set; }
+
 		public event EventHandler CurrentAtlasFull;
 
 #if MONOGAME || FNA || STRIDE
-		public FontSystem(IFontLoader fontLoader, GraphicsDevice graphicsDevice, int width = 1024, int height = 1024, int blurAmount = 0, int strokeAmount = 0, bool premultiplyAlpha = true)
+		public FontSystem(IFontLoader fontLoader, GraphicsDevice graphicsDevice, int width = 1024, int height = 1024, int blurAmount = 0, int strokeAmount = 0, bool premultiplyAlpha = true, float fontResolutionFactor = 1f, int kernelWidth = 0, int kernelHeight = 0)
 #else
-		public FontSystem(IFontLoader fontLoader, ITexture2DManager textureCreator, int width = 1024, int height = 1024, int blurAmount = 0, int strokeAmount = 0, bool premultiplyAlpha = true)
+		public FontSystem(IFontLoader fontLoader, ITexture2DManager textureCreator, int width = 1024, int height = 1024, int blurAmount = 0, int strokeAmount = 0, bool premultiplyAlpha = true, float fontResolutionFactor = 1f, int kernelWidth = 0, int kernelHeight = 0)
 #endif
 		{
 			if (fontLoader == null)
@@ -114,9 +119,27 @@ namespace FontStashSharp
 				throw new ArgumentException("Cannot have both blur and stroke.");
 			}
 
+			if(fontResolutionFactor < 0)
+			{
+				throw new ArgumentOutOfRangeException(nameof(fontResolutionFactor), fontResolutionFactor, "This cannot be smaller than 0");
+			}
+
+			if (kernelWidth < 0)
+			{
+				throw new ArgumentOutOfRangeException(nameof(kernelWidth), kernelWidth, "This cannot be smaller than 0");
+			}
+
+			if (kernelHeight < 0)
+			{
+				throw new ArgumentOutOfRangeException(nameof(kernelHeight), kernelHeight, "This cannot be smaller than 0");
+			}
+
 			BlurAmount = blurAmount;
 			StrokeAmount = strokeAmount;
 			PremultiplyAlpha = premultiplyAlpha;
+			FontResolutionFactor = fontResolutionFactor;
+			KernelWidth = kernelWidth;
+			KernelHeight = kernelHeight;
 
 			_size = new Point(width, height);
 		}
@@ -205,28 +228,7 @@ namespace FontStashSharp
 			return g;
 		}
 
-		internal int? GetCodepointIndex(int codepoint, out IDynamicFontSource font)
-		{
-			font = null;
-
-			var g = default(int?);
-			foreach (var f in _fontSources)
-			{
-				if(f is IDynamicFontSource df)
-				{
-					g = df.GetGlyphId(codepoint);
-					if (g != null)
-					{
-						font = df;
-						break;
-					}
-				}
-			}
-
-			return g;
-		}
-
-		internal void RenderGlyphOnAtlas(DynamicFontGlyph glyph, bool prefilter)
+		internal void RenderGlyphOnAtlas(DynamicFontGlyph glyph)
 		{
 			var currentAtlas = CurrentAtlas;
 			int gx = 0, gy = 0;
@@ -251,9 +253,9 @@ namespace FontStashSharp
 			glyph.Bounds.Y = gy;
 
 #if MONOGAME || FNA || STRIDE
-			currentAtlas.RenderGlyph(_graphicsDevice, glyph, BlurAmount, StrokeAmount, PremultiplyAlpha);
+			currentAtlas.RenderGlyph(_graphicsDevice, glyph, BlurAmount, StrokeAmount, PremultiplyAlpha, KernelWidth, KernelHeight);
 #else
-			currentAtlas.RenderGlyph(_textureCreator, glyph, BlurAmount, StrokeAmount, PremultiplyAlpha);
+			currentAtlas.RenderGlyph(_textureCreator, glyph, BlurAmount, StrokeAmount, PremultiplyAlpha, KernelWidth, KernelHeight);
 #endif
 
 			glyph.Texture = currentAtlas.Texture;

--- a/src/FontStashSharp/Interfaces/IFontLoader.cs
+++ b/src/FontStashSharp/Interfaces/IFontLoader.cs
@@ -54,6 +54,21 @@ namespace FontStashSharp.Interfaces
 		int GetGlyphKernAdvance(int previousGlyphId, int glyphId, int fontSize);
 	}
 
+	public interface IDynamicFontSource : IFontSource
+  {
+
+		/// <summary>
+		/// Renders a glyph 
+		/// </summary>
+		/// <param name="buffer"></param>
+		/// <param name="fontSize"></param>
+		/// <param name="startIndex"></param>
+		/// <param name="outWidth"></param>
+		/// <param name="outHeight"></param>
+		/// <param name="outStride"></param>
+		void RasterizeGlyphBitmap(int glyphId, int fontSize, byte[] buffer, int startIndex, int outWidth, int outHeight, int outStride, uint kernelWidth);
+	}
+
 	/// <summary>
 	/// Font Rasterization Service
 	/// </summary>

--- a/src/FontStashSharp/Interfaces/IFontLoader.cs
+++ b/src/FontStashSharp/Interfaces/IFontLoader.cs
@@ -42,7 +42,7 @@ namespace FontStashSharp.Interfaces
 		/// <param name="outWidth"></param>
 		/// <param name="outHeight"></param>
 		/// <param name="outStride"></param>
-		void RasterizeGlyphBitmap(int glyphId, int fontSize, byte[] buffer, int startIndex, int outWidth, int outHeight, int outStride);
+		void RasterizeGlyphBitmap(int glyphId, int fontSize, byte[] buffer, int startIndex, int outWidth, int outHeight, int outStride, int kernelWidth, int kernelHeight);
 
 		/// <summary>
 		/// Returns kerning
@@ -52,21 +52,6 @@ namespace FontStashSharp.Interfaces
 		/// <param name="fontSize"></param>
 		/// <returns></returns>
 		int GetGlyphKernAdvance(int previousGlyphId, int glyphId, int fontSize);
-	}
-
-	public interface IDynamicFontSource : IFontSource
-  {
-
-		/// <summary>
-		/// Renders a glyph 
-		/// </summary>
-		/// <param name="buffer"></param>
-		/// <param name="fontSize"></param>
-		/// <param name="startIndex"></param>
-		/// <param name="outWidth"></param>
-		/// <param name="outHeight"></param>
-		/// <param name="outStride"></param>
-		void RasterizeGlyphBitmap(int glyphId, int fontSize, byte[] buffer, int startIndex, int outWidth, int outHeight, int outStride, uint kernelWidth);
 	}
 
 	/// <summary>

--- a/src/FontStashSharp/SpriteFontBase.cs
+++ b/src/FontStashSharp/SpriteFontBase.cs
@@ -416,6 +416,7 @@ namespace FontStashSharp
 
 			float ascent, lineHeight;
 			PreDraw(str, out ascent, out lineHeight, true);
+
 			var x = position.X;
 			var y = position.Y;
 			var q = new FontGlyphSquad();

--- a/src/FontStashSharp/SpriteFontBase.cs
+++ b/src/FontStashSharp/SpriteFontBase.cs
@@ -22,17 +22,16 @@ namespace FontStashSharp
 		/// Line height in pixels
 		/// </summary>
 		public int FontSize { get; private set; }
-		
-		public int RenderFontSizeMultiplicator { get; protected set; }
+
+		protected float RenderFontSizeMultiplicator { get; set; } = 1f;
 
 		protected SpriteFontBase(int fontSize)
 		{
 			FontSize = fontSize;
-			RenderFontSizeMultiplicator = 2;
 		}
 
-		protected internal abstract FontGlyph GetGlyph(int codepoint, bool withoutBitmap, bool isForMeasurement);
-		protected abstract void PreDraw(string str, out float ascent, out float lineHeight, bool isForMeasurement);
+		protected internal abstract FontGlyph GetGlyph(int codepoint, bool withoutBitmap);
+		protected abstract void PreDraw(string str, out float ascent, out float lineHeight, bool withoutBitmap);
 
 		/// <summary>
 		/// Draws a text
@@ -71,7 +70,7 @@ namespace FontStashSharp
 					continue;
 				}
 
-				var glyph = GetGlyph(codepoint, false, false);
+				var glyph = GetGlyph(codepoint, false);
 				if (glyph == null)
 				{
 					continue;
@@ -165,7 +164,7 @@ namespace FontStashSharp
 					continue;
 				}
 
-				var glyph = GetGlyph(codepoint, false, false);
+				var glyph = GetGlyph(codepoint, false);
 				if (glyph == null)
 				{
 					++pos;
@@ -261,7 +260,7 @@ namespace FontStashSharp
 					continue;
 				}
 
-				var glyph = GetGlyph(codepoint, false, false);
+				var glyph = GetGlyph(codepoint, false);
 				if (glyph == null)
 				{
 					continue;
@@ -355,7 +354,7 @@ namespace FontStashSharp
 					continue;
 				}
 
-				var glyph = GetGlyph(codepoint, false, false);
+				var glyph = GetGlyph(codepoint, false);
 				if (glyph == null)
 				{
 					++pos;
@@ -440,7 +439,7 @@ namespace FontStashSharp
 					continue;
 				}
 
-				var glyph = GetGlyph(codepoint, true, true);
+				var glyph = GetGlyph(codepoint, true);
 				if (glyph == null)
 				{
 					continue;
@@ -507,7 +506,7 @@ namespace FontStashSharp
 					continue;
 				}
 
-				var glyph = GetGlyph(codepoint, true, true);
+				var glyph = GetGlyph(codepoint, true);
 				if (glyph == null)
 				{
 					continue;
@@ -571,7 +570,7 @@ namespace FontStashSharp
 					continue;
 				}
 
-				var glyph = GetGlyph(codepoint, true, true);
+				var glyph = GetGlyph(codepoint, true);
 				if (glyph == null)
 				{
 					continue;
@@ -624,7 +623,7 @@ namespace FontStashSharp
 					continue;
 				}
 
-				var glyph = GetGlyph(codepoint, true, true);
+				var glyph = GetGlyph(codepoint, true);
 				if (glyph == null)
 				{
 					continue;

--- a/src/FontStashSharp/SpriteFontBase.cs
+++ b/src/FontStashSharp/SpriteFontBase.cs
@@ -22,13 +22,16 @@ namespace FontStashSharp
 		/// Line height in pixels
 		/// </summary>
 		public int FontSize { get; private set; }
+		
+		public int RenderFontSize { get; private set; }
 
 		protected SpriteFontBase(int fontSize)
 		{
 			FontSize = fontSize;
+			RenderFontSize = fontSize * 4;
 		}
 
-		protected internal abstract FontGlyph GetGlyph(int codepoint, bool withoutBitmap);
+		protected internal abstract FontGlyph GetGlyph(int codepoint, bool withoutBitmap, bool isForRendering);
 		protected abstract void PreDraw(string str, out float ascent, out float lineHeight);
 
 		/// <summary>
@@ -68,13 +71,16 @@ namespace FontStashSharp
 					continue;
 				}
 
-				var glyph = GetGlyph(codepoint, false);
+				// For rendering we switch to a glyph which has a higher resolution but needs to be rendered at the same position
+				// now we just need to do some correct scaling, such that he font isn't twice the size on the screen ;)
+				var glyph = GetGlyph(codepoint, false, true);
 				if (glyph == null)
 				{
 					continue;
 				}
 
 				GetQuad(glyph, prevGlyph, scale, ref originX, ref originY, ref q);
+
 				if (!glyph.IsEmpty)
 				{
 					var sourceRect = new Rectangle((int)q.S0, (int)q.T0, (int)(q.S1 - q.S0), (int)(q.T1 - q.T0));
@@ -85,7 +91,7 @@ namespace FontStashSharp
 						color,
 						rotation,
 						origin - q.Offset,
-						scale,
+						scale * ((float)FontSize / ((float)RenderFontSize)),
 						layerDepth);
 				}
 
@@ -162,7 +168,9 @@ namespace FontStashSharp
 					continue;
 				}
 
-				var glyph = GetGlyph(codepoint, false);
+				// For rendering we switch to a glyph which has a higher resolution but needs to be rendered at the same position
+				// now we just need to do some correct scaling, such that he font isn't twice the size on the screen ;)
+				var glyph = GetGlyph(codepoint, false, true);
 				if (glyph == null)
 				{
 					++pos;
@@ -170,6 +178,7 @@ namespace FontStashSharp
 				}
 
 				GetQuad(glyph, prevGlyph, scale, ref originX, ref originY, ref q);
+
 				if (!glyph.IsEmpty)
 				{
 					var sourceRect = new Rectangle((int)q.S0, (int)q.T0, (int)(q.S1 - q.S0), (int)(q.T1 - q.T0));
@@ -180,7 +189,7 @@ namespace FontStashSharp
 						colors[pos],
 						rotation,
 						origin - q.Offset,
-						scale,
+						scale * ((float)FontSize / ((float)RenderFontSize)),
 						layerDepth);
 				}
 
@@ -258,13 +267,15 @@ namespace FontStashSharp
 					continue;
 				}
 
-				var glyph = GetGlyph(codepoint, false);
+				var glyph = GetGlyph(codepoint, false, true);
 				if (glyph == null)
 				{
 					continue;
 				}
 
 				GetQuad(glyph, prevGlyph, scale, ref originX, ref originY, ref q);
+
+
 				if (!glyph.IsEmpty)
 				{
 					var sourceRect = new Rectangle((int)q.S0, (int)q.T0, (int)(q.S1 - q.S0), (int)(q.T1 - q.T0));
@@ -275,7 +286,7 @@ namespace FontStashSharp
 						color,
 						rotation,
 						origin - q.Offset,
-						scale,
+						scale * ((float)FontSize / ((float)RenderFontSize)),
 						layerDepth);
 				}
 
@@ -352,7 +363,7 @@ namespace FontStashSharp
 					continue;
 				}
 
-				var glyph = GetGlyph(codepoint, false);
+				var glyph = GetGlyph(codepoint, false, true);
 				if (glyph == null)
 				{
 					++pos;
@@ -360,6 +371,7 @@ namespace FontStashSharp
 				}
 
 				GetQuad(glyph, prevGlyph, scale, ref originX, ref originY, ref q);
+
 				if (!glyph.IsEmpty)
 				{
 					var sourceRect = new Rectangle((int)q.S0, (int)q.T0, (int)(q.S1 - q.S0), (int)(q.T1 - q.T0));
@@ -370,7 +382,7 @@ namespace FontStashSharp
 						colors[pos],
 						rotation,
 						origin - q.Offset,
-						scale,
+						scale * ((float)FontSize / ((float)RenderFontSize)),
 						layerDepth);
 				}
 
@@ -414,7 +426,7 @@ namespace FontStashSharp
 
 			float ascent, lineHeight;
 			PreDraw(str, out ascent, out lineHeight);
-
+			// lineHeight *= ((float)FontSize / (float)RenderFontSize);
 			var x = position.X;
 			var y = position.Y;
 			var q = new FontGlyphSquad();
@@ -438,7 +450,7 @@ namespace FontStashSharp
 					continue;
 				}
 
-				var glyph = GetGlyph(codepoint, true);
+				var glyph = GetGlyph(codepoint, true, true);
 				if (glyph == null)
 				{
 					continue;
@@ -447,7 +459,7 @@ namespace FontStashSharp
 				GetQuad(glyph, prevGlyph, scale, ref x, ref y, ref q);
 				if (q.X0 < minx)
 					minx = q.X0;
-				var scaledX = x * scale.X;
+				var scaledX = x * scale.X ;
 				if (scaledX > maxx)
 					maxx = scaledX;
 
@@ -505,7 +517,7 @@ namespace FontStashSharp
 					continue;
 				}
 
-				var glyph = GetGlyph(codepoint, true);
+				var glyph = GetGlyph(codepoint, true, true);
 				if (glyph == null)
 				{
 					continue;
@@ -569,7 +581,7 @@ namespace FontStashSharp
 					continue;
 				}
 
-				var glyph = GetGlyph(codepoint, true);
+				var glyph = GetGlyph(codepoint, true, true);
 				if (glyph == null)
 				{
 					continue;
@@ -622,13 +634,13 @@ namespace FontStashSharp
 					continue;
 				}
 
-				var glyph = GetGlyph(codepoint, true);
+				var glyph = GetGlyph(codepoint, true, false);
 				if (glyph == null)
 				{
 					continue;
 				}
 
-				GetQuad(glyph, prevGlyph, scale, ref x, ref y, ref q);
+				GetQuad(glyph, prevGlyph, glyph, prevGlyph, scale, ref x, ref y, ref q);
 
 				Rects.Add(new Rectangle((int)q.X0, (int)q.Y0, (int)(q.X1 - q.X0), (int)(q.Y1 - q.Y0)));
 				prevGlyph = glyph;
@@ -686,6 +698,7 @@ namespace FontStashSharp
 
 		internal virtual void GetQuad(FontGlyph glyph, FontGlyph prevGlyph, Vector2 scale, ref float x, ref float y, ref FontGlyphSquad q)
 		{
+			scale *= ((float)FontSize / ((float)RenderFontSize));
 			float rx = x + glyph.XOffset;
 			float ry = y + glyph.YOffset;
 			q.X0 = rx * scale.X;

--- a/src/FontStashSharp/SpriteFontBase.cs
+++ b/src/FontStashSharp/SpriteFontBase.cs
@@ -23,12 +23,12 @@ namespace FontStashSharp
 		/// </summary>
 		public int FontSize { get; private set; }
 		
-		public int RenderFontSize { get; private set; }
+		public int RenderFontSizeMultiplicator { get; protected set; }
 
 		protected SpriteFontBase(int fontSize)
 		{
 			FontSize = fontSize;
-			RenderFontSize = fontSize * 4;
+			RenderFontSizeMultiplicator = 2;
 		}
 
 		protected internal abstract FontGlyph GetGlyph(int codepoint, bool withoutBitmap);
@@ -87,8 +87,8 @@ namespace FontStashSharp
 						sourceRect,
 						color,
 						rotation,
-						origin * (((float)RenderFontSize) / (float)FontSize) - q.Offset,
-						scale * ((float)FontSize / ((float)RenderFontSize)),
+						origin * (float) RenderFontSizeMultiplicator - q.Offset,
+						scale / (float)RenderFontSizeMultiplicator,
 						layerDepth);
 				}
 
@@ -182,8 +182,8 @@ namespace FontStashSharp
 						sourceRect,
 						colors[pos],
 						rotation,
-						origin * (((float)RenderFontSize) / (float)FontSize) - q.Offset,
-						scale * ((float)FontSize / ((float)RenderFontSize)),
+						origin * (float)RenderFontSizeMultiplicator - q.Offset,
+						scale / (float)RenderFontSizeMultiplicator,
 						layerDepth);
 				}
 
@@ -277,8 +277,8 @@ namespace FontStashSharp
 						sourceRect,
 						color,
 						rotation,
-						origin * (((float)RenderFontSize) / (float)FontSize) - q.Offset,
-						scale * ((float)FontSize / ((float)RenderFontSize)),
+						origin * (float)RenderFontSizeMultiplicator - q.Offset,
+						scale / (float)RenderFontSizeMultiplicator,
 						layerDepth);
 				}
 
@@ -372,8 +372,8 @@ namespace FontStashSharp
 						sourceRect,
 						colors[pos],
 						rotation,
-						origin - q.Offset,
-						scale * ((float)FontSize / ((float)RenderFontSize)),
+						origin * (float)RenderFontSizeMultiplicator - q.Offset,
+						scale / (float)RenderFontSizeMultiplicator,
 						layerDepth);
 				}
 
@@ -446,10 +446,10 @@ namespace FontStashSharp
 					continue;
 				}
 
-				GetQuad(glyph, prevGlyph, scale / ((float)FontSize / ((float)RenderFontSize)), ref x, ref y, ref q);
+				GetQuad(glyph, prevGlyph, scale * (float)RenderFontSizeMultiplicator, ref x, ref y, ref q);
 				if (q.X0 < minx)
 					minx = q.X0;
-				var scaledX = x * scale.X * ((float)FontSize / ((float)RenderFontSize));
+				var scaledX = x * scale.X / (float) RenderFontSizeMultiplicator;
 				if (scaledX > maxx)
 					maxx = scaledX;
 
@@ -513,10 +513,10 @@ namespace FontStashSharp
 					continue;
 				}
 
-				GetQuad(glyph, prevGlyph, scale / ((float)FontSize / ((float)RenderFontSize)), ref x, ref y, ref q);
+				GetQuad(glyph, prevGlyph, scale * (float)RenderFontSizeMultiplicator, ref x, ref y, ref q);
 				if (q.X0 < minx)
 					minx = q.X0;
-				var scaledX = x * scale.X;
+				var scaledX = x * scale.X / (float)RenderFontSizeMultiplicator;
 				if (scaledX > maxx)
 					maxx = scaledX;
 
@@ -577,7 +577,7 @@ namespace FontStashSharp
 					continue;
 				}
 
-				GetQuad(glyph, prevGlyph, scale / ((float)FontSize / ((float)RenderFontSize)), ref x, ref y, ref q);
+				GetQuad(glyph, prevGlyph, scale * (float)RenderFontSizeMultiplicator, ref x, ref y, ref q);
 
 				Rects.Add(new Rectangle((int)q.X0, (int)q.Y0, (int)(q.X1 - q.X0), (int)(q.Y1 - q.Y0)));
 				prevGlyph = glyph;
@@ -630,7 +630,7 @@ namespace FontStashSharp
 					continue;
 				}
 
-				GetQuad(glyph, prevGlyph, scale / ((float)FontSize / ((float)RenderFontSize)), ref x, ref y, ref q);
+				GetQuad(glyph, prevGlyph, scale * (float)RenderFontSizeMultiplicator, ref x, ref y, ref q);
 
 				Rects.Add(new Rectangle((int)q.X0, (int)q.Y0, (int)(q.X1 - q.X0), (int)(q.Y1 - q.Y0)));
 				prevGlyph = glyph;
@@ -688,13 +688,13 @@ namespace FontStashSharp
 
 		internal virtual void GetQuad(FontGlyph glyph, FontGlyph prevGlyph, Vector2 scale, ref float x, ref float y, ref FontGlyphSquad q)
 		{
-			scale *= ((float)FontSize / ((float)RenderFontSize));
+			var currScale = scale / (float)RenderFontSizeMultiplicator;
 			float rx = x + glyph.XOffset;
 			float ry = y + glyph.YOffset;
-			q.X0 = rx * scale.X;
-			q.Y0 = ry * scale.Y;
-			q.X1 = (rx + glyph.Bounds.Width) * scale.X;
-			q.Y1 = (ry + glyph.Bounds.Height) * scale.Y;
+			q.X0 = rx * currScale.X;
+			q.Y0 = ry * currScale.Y;
+			q.X1 = (rx + glyph.Bounds.Width) * currScale.X;
+			q.Y1 = (ry + glyph.Bounds.Height) * currScale.Y;
 			q.S0 = glyph.Bounds.X;
 			q.T0 = glyph.Bounds.Y;
 			q.S1 = glyph.Bounds.Right;

--- a/src/FontStashSharp/SpriteFontBase.cs
+++ b/src/FontStashSharp/SpriteFontBase.cs
@@ -28,10 +28,10 @@ namespace FontStashSharp
 		protected SpriteFontBase(int fontSize)
 		{
 			FontSize = fontSize;
-			RenderFontSizeMultiplicator = 2;
+			RenderFontSizeMultiplicator = 8;
 		}
 
-		protected internal abstract FontGlyph GetGlyph(int codepoint, bool withoutBitmap);
+		protected internal abstract FontGlyph GetGlyph(int codepoint, bool withoutBitmap, bool isForMeasurement);
 		protected abstract void PreDraw(string str, out float ascent, out float lineHeight, bool isForMeasurement);
 
 		/// <summary>
@@ -71,13 +71,13 @@ namespace FontStashSharp
 					continue;
 				}
 
-				var glyph = GetGlyph(codepoint, false);
+				var glyph = GetGlyph(codepoint, false, false);
 				if (glyph == null)
 				{
 					continue;
 				}
 
-				GetQuad(glyph, prevGlyph, scale, ref originX, ref originY, ref q);
+				GetQuad(glyph, prevGlyph, scale / (float)RenderFontSizeMultiplicator, ref originX, ref originY, ref q);
 				if (!glyph.IsEmpty)
 				{
 					var sourceRect = new Rectangle((int)q.S0, (int)q.T0, (int)(q.S1 - q.S0), (int)(q.T1 - q.T0));
@@ -165,14 +165,14 @@ namespace FontStashSharp
 					continue;
 				}
 
-				var glyph = GetGlyph(codepoint, false);
+				var glyph = GetGlyph(codepoint, false, false);
 				if (glyph == null)
 				{
 					++pos;
 					continue;
 				}
 
-				GetQuad(glyph, prevGlyph, scale, ref originX, ref originY, ref q);
+				GetQuad(glyph, prevGlyph, scale / (float)RenderFontSizeMultiplicator, ref originX, ref originY, ref q);
 				if (!glyph.IsEmpty)
 				{
 					var sourceRect = new Rectangle((int)q.S0, (int)q.T0, (int)(q.S1 - q.S0), (int)(q.T1 - q.T0));
@@ -261,13 +261,13 @@ namespace FontStashSharp
 					continue;
 				}
 
-				var glyph = GetGlyph(codepoint, false);
+				var glyph = GetGlyph(codepoint, false, false);
 				if (glyph == null)
 				{
 					continue;
 				}
 
-				GetQuad(glyph, prevGlyph, scale, ref originX, ref originY, ref q);
+				GetQuad(glyph, prevGlyph, scale / (float)RenderFontSizeMultiplicator, ref originX, ref originY, ref q);
 				if (!glyph.IsEmpty)
 				{
 					var sourceRect = new Rectangle((int)q.S0, (int)q.T0, (int)(q.S1 - q.S0), (int)(q.T1 - q.T0));
@@ -355,14 +355,14 @@ namespace FontStashSharp
 					continue;
 				}
 
-				var glyph = GetGlyph(codepoint, false);
+				var glyph = GetGlyph(codepoint, false, false);
 				if (glyph == null)
 				{
 					++pos;
 					continue;
 				}
 
-				GetQuad(glyph, prevGlyph, scale, ref originX, ref originY, ref q);
+				GetQuad(glyph, prevGlyph, scale / (float)RenderFontSizeMultiplicator, ref originX, ref originY, ref q);
 				if (!glyph.IsEmpty)
 				{
 					var sourceRect = new Rectangle((int)q.S0, (int)q.T0, (int)(q.S1 - q.S0), (int)(q.T1 - q.T0));
@@ -440,16 +440,16 @@ namespace FontStashSharp
 					continue;
 				}
 
-				var glyph = GetGlyph(codepoint, true);
+				var glyph = GetGlyph(codepoint, true, true);
 				if (glyph == null)
 				{
 					continue;
 				}
 
-				GetQuad(glyph, prevGlyph, scale * (float)RenderFontSizeMultiplicator, ref x, ref y, ref q);
+				GetQuad(glyph, prevGlyph, scale, ref x, ref y, ref q);
 				if (q.X0 < minx)
 					minx = q.X0;
-				var scaledX = x * scale.X / (float) RenderFontSizeMultiplicator;
+				var scaledX = x * scale.X;
 				if (scaledX > maxx)
 					maxx = scaledX;
 
@@ -507,16 +507,16 @@ namespace FontStashSharp
 					continue;
 				}
 
-				var glyph = GetGlyph(codepoint, true);
+				var glyph = GetGlyph(codepoint, true, true);
 				if (glyph == null)
 				{
 					continue;
 				}
 
-				GetQuad(glyph, prevGlyph, scale * (float)RenderFontSizeMultiplicator, ref x, ref y, ref q);
+				GetQuad(glyph, prevGlyph, scale, ref x, ref y, ref q);
 				if (q.X0 < minx)
 					minx = q.X0;
-				var scaledX = x * scale.X / (float)RenderFontSizeMultiplicator;
+				var scaledX = x * scale.X;
 				if (scaledX > maxx)
 					maxx = scaledX;
 
@@ -571,13 +571,13 @@ namespace FontStashSharp
 					continue;
 				}
 
-				var glyph = GetGlyph(codepoint, true);
+				var glyph = GetGlyph(codepoint, true, true);
 				if (glyph == null)
 				{
 					continue;
 				}
 
-				GetQuad(glyph, prevGlyph, scale * (float)RenderFontSizeMultiplicator, ref x, ref y, ref q);
+				GetQuad(glyph, prevGlyph, scale, ref x, ref y, ref q);
 
 				Rects.Add(new Rectangle((int)q.X0, (int)q.Y0, (int)(q.X1 - q.X0), (int)(q.Y1 - q.Y0)));
 				prevGlyph = glyph;
@@ -624,13 +624,13 @@ namespace FontStashSharp
 					continue;
 				}
 
-				var glyph = GetGlyph(codepoint, true);
+				var glyph = GetGlyph(codepoint, true, true);
 				if (glyph == null)
 				{
 					continue;
 				}
 
-				GetQuad(glyph, prevGlyph, scale * (float)RenderFontSizeMultiplicator, ref x, ref y, ref q);
+				GetQuad(glyph, prevGlyph, scale, ref x, ref y, ref q);
 
 				Rects.Add(new Rectangle((int)q.X0, (int)q.Y0, (int)(q.X1 - q.X0), (int)(q.Y1 - q.Y0)));
 				prevGlyph = glyph;
@@ -688,13 +688,12 @@ namespace FontStashSharp
 
 		internal virtual void GetQuad(FontGlyph glyph, FontGlyph prevGlyph, Vector2 scale, ref float x, ref float y, ref FontGlyphSquad q)
 		{
-			var currScale = scale / (float)RenderFontSizeMultiplicator;
 			float rx = x + glyph.XOffset;
 			float ry = y + glyph.YOffset;
-			q.X0 = rx * currScale.X;
-			q.Y0 = ry * currScale.Y;
-			q.X1 = (rx + glyph.Bounds.Width) * currScale.X;
-			q.Y1 = (ry + glyph.Bounds.Height) * currScale.Y;
+			q.X0 = rx * scale.X;
+			q.Y0 = ry * scale.Y;
+			q.X1 = (rx + glyph.Bounds.Width) * scale.X;
+			q.Y1 = (ry + glyph.Bounds.Height) * scale.Y;
 			q.S0 = glyph.Bounds.X;
 			q.T0 = glyph.Bounds.Y;
 			q.S1 = glyph.Bounds.Right;

--- a/src/FontStashSharp/SpriteFontBase.cs
+++ b/src/FontStashSharp/SpriteFontBase.cs
@@ -28,7 +28,7 @@ namespace FontStashSharp
 		protected SpriteFontBase(int fontSize)
 		{
 			FontSize = fontSize;
-			RenderFontSizeMultiplicator = 8;
+			RenderFontSizeMultiplicator = 2;
 		}
 
 		protected internal abstract FontGlyph GetGlyph(int codepoint, bool withoutBitmap, bool isForMeasurement);

--- a/src/FontStashSharp/SpriteFontBase.cs
+++ b/src/FontStashSharp/SpriteFontBase.cs
@@ -71,7 +71,6 @@ namespace FontStashSharp
 					continue;
 				}
 
-
 				var glyph = GetGlyph(codepoint, false);
 				if (glyph == null)
 				{
@@ -79,7 +78,6 @@ namespace FontStashSharp
 				}
 
 				GetQuad(glyph, prevGlyph, scale, ref originX, ref originY, ref q);
-
 				if (!glyph.IsEmpty)
 				{
 					var sourceRect = new Rectangle((int)q.S0, (int)q.T0, (int)(q.S1 - q.S0), (int)(q.T1 - q.T0));
@@ -175,7 +173,6 @@ namespace FontStashSharp
 				}
 
 				GetQuad(glyph, prevGlyph, scale, ref originX, ref originY, ref q);
-
 				if (!glyph.IsEmpty)
 				{
 					var sourceRect = new Rectangle((int)q.S0, (int)q.T0, (int)(q.S1 - q.S0), (int)(q.T1 - q.T0));
@@ -366,7 +363,6 @@ namespace FontStashSharp
 				}
 
 				GetQuad(glyph, prevGlyph, scale, ref originX, ref originY, ref q);
-
 				if (!glyph.IsEmpty)
 				{
 					var sourceRect = new Rectangle((int)q.S0, (int)q.T0, (int)(q.S1 - q.S0), (int)(q.T1 - q.T0));
@@ -421,7 +417,6 @@ namespace FontStashSharp
 
 			float ascent, lineHeight;
 			PreDraw(str, out ascent, out lineHeight);
-			// lineHeight *= ((float)FontSize / (float)RenderFontSize);
 			var x = position.X;
 			var y = position.Y;
 			var q = new FontGlyphSquad();
@@ -454,7 +449,7 @@ namespace FontStashSharp
 				GetQuad(glyph, prevGlyph, scale, ref x, ref y, ref q);
 				if (q.X0 < minx)
 					minx = q.X0;
-				var scaledX = x * scale.X ;
+				var scaledX = x * scale.X;
 				if (scaledX > maxx)
 					maxx = scaledX;
 

--- a/src/FontStashSharp/SpriteFontBase.cs
+++ b/src/FontStashSharp/SpriteFontBase.cs
@@ -32,7 +32,7 @@ namespace FontStashSharp
 		}
 
 		protected internal abstract FontGlyph GetGlyph(int codepoint, bool withoutBitmap);
-		protected abstract void PreDraw(string str, out float ascent, out float lineHeight);
+		protected abstract void PreDraw(string str, out float ascent, out float lineHeight, bool isForMeasurement);
 
 		/// <summary>
 		/// Draws a text
@@ -51,7 +51,7 @@ namespace FontStashSharp
 			if (string.IsNullOrEmpty(text)) return 0.0f;
 
 			float ascent, lineHeight;
-			PreDraw(text, out ascent, out lineHeight);
+			PreDraw(text, out ascent, out lineHeight, false);
 
 			float originX = 0.0f;
 			float originY = 0.0f;
@@ -87,7 +87,7 @@ namespace FontStashSharp
 						sourceRect,
 						color,
 						rotation,
-						origin - q.Offset,
+						origin * (((float)RenderFontSize) / (float)FontSize) - q.Offset,
 						scale * ((float)FontSize / ((float)RenderFontSize)),
 						layerDepth);
 				}
@@ -142,7 +142,7 @@ namespace FontStashSharp
 			if (string.IsNullOrEmpty(text)) return 0.0f;
 
 			float ascent, lineHeight;
-			PreDraw(text, out ascent, out lineHeight);
+			PreDraw(text, out ascent, out lineHeight, false);
 
 			float originX = 0.0f;
 			float originY = 0.0f;
@@ -182,7 +182,7 @@ namespace FontStashSharp
 						sourceRect,
 						colors[pos],
 						rotation,
-						origin - q.Offset,
+						origin * (((float)RenderFontSize) / (float)FontSize) - q.Offset,
 						scale * ((float)FontSize / ((float)RenderFontSize)),
 						layerDepth);
 				}
@@ -221,7 +221,7 @@ namespace FontStashSharp
 			return DrawText(renderer, text, position, colors, DefaultScale, 0, DefaultOrigin, layerDepth);
 		}
 
-		protected abstract void PreDraw(StringBuilder str, out float ascent, out float lineHeight);
+		protected abstract void PreDraw(StringBuilder str, out float ascent, out float lineHeight, bool isForMeasurement);
 
 		/// <summary>
 		/// Draws a text
@@ -240,7 +240,7 @@ namespace FontStashSharp
 			if (text == null || text.Length == 0) return 0.0f;
 
 			float ascent, lineHeight;
-			PreDraw(text, out ascent, out lineHeight);
+			PreDraw(text, out ascent, out lineHeight, false);
 
 			float originX = 0.0f;
 			float originY = 0.0f;
@@ -277,7 +277,7 @@ namespace FontStashSharp
 						sourceRect,
 						color,
 						rotation,
-						origin - q.Offset,
+						origin * (((float)RenderFontSize) / (float)FontSize) - q.Offset,
 						scale * ((float)FontSize / ((float)RenderFontSize)),
 						layerDepth);
 				}
@@ -332,7 +332,7 @@ namespace FontStashSharp
 			if (text == null || text.Length == 0) return 0.0f;
 
 			float ascent, lineHeight;
-			PreDraw(text, out ascent, out lineHeight);
+			PreDraw(text, out ascent, out lineHeight, false);
 
 			float originX = 0.0f;
 			float originY = 0.0f;
@@ -416,7 +416,7 @@ namespace FontStashSharp
 			if (string.IsNullOrEmpty(str)) return 0.0f;
 
 			float ascent, lineHeight;
-			PreDraw(str, out ascent, out lineHeight);
+			PreDraw(str, out ascent, out lineHeight, true);
 			var x = position.X;
 			var y = position.Y;
 			var q = new FontGlyphSquad();
@@ -446,10 +446,10 @@ namespace FontStashSharp
 					continue;
 				}
 
-				GetQuad(glyph, prevGlyph, scale, ref x, ref y, ref q);
+				GetQuad(glyph, prevGlyph, scale / ((float)FontSize / ((float)RenderFontSize)), ref x, ref y, ref q);
 				if (q.X0 < minx)
 					minx = q.X0;
-				var scaledX = x * scale.X;
+				var scaledX = x * scale.X * ((float)FontSize / ((float)RenderFontSize));
 				if (scaledX > maxx)
 					maxx = scaledX;
 
@@ -480,7 +480,7 @@ namespace FontStashSharp
 			if (str == null || str.Length == 0) return 0.0f;
 
 			float ascent, lineHeight;
-			PreDraw(str, out ascent, out lineHeight);
+			PreDraw(str, out ascent, out lineHeight, true);
 
 			var q = new FontGlyphSquad();
 
@@ -513,7 +513,7 @@ namespace FontStashSharp
 					continue;
 				}
 
-				GetQuad(glyph, prevGlyph, scale, ref x, ref y, ref q);
+				GetQuad(glyph, prevGlyph, scale / ((float)FontSize / ((float)RenderFontSize)), ref x, ref y, ref q);
 				if (q.X0 < minx)
 					minx = q.X0;
 				var scaledX = x * scale.X;
@@ -548,7 +548,7 @@ namespace FontStashSharp
 			if (string.IsNullOrEmpty(str)) return Rects;
 
 			float ascent, lineHeight;
-			PreDraw(str, out ascent, out lineHeight);
+			PreDraw(str, out ascent, out lineHeight, true);
 
 			var q = new FontGlyphSquad();
 
@@ -577,7 +577,7 @@ namespace FontStashSharp
 					continue;
 				}
 
-				GetQuad(glyph, prevGlyph, scale, ref x, ref y, ref q);
+				GetQuad(glyph, prevGlyph, scale / ((float)FontSize / ((float)RenderFontSize)), ref x, ref y, ref q);
 
 				Rects.Add(new Rectangle((int)q.X0, (int)q.Y0, (int)(q.X1 - q.X0), (int)(q.Y1 - q.Y0)));
 				prevGlyph = glyph;
@@ -597,7 +597,7 @@ namespace FontStashSharp
 			if (str == null || str.Length == 0) return Rects;
 
 			float ascent, lineHeight;
-			PreDraw(str, out ascent, out lineHeight);
+			PreDraw(str, out ascent, out lineHeight, true);
 
 			var q = new FontGlyphSquad();
 
@@ -630,7 +630,7 @@ namespace FontStashSharp
 					continue;
 				}
 
-				GetQuad(glyph, prevGlyph, scale, ref x, ref y, ref q);
+				GetQuad(glyph, prevGlyph, scale / ((float)FontSize / ((float)RenderFontSize)), ref x, ref y, ref q);
 
 				Rects.Add(new Rectangle((int)q.X0, (int)q.Y0, (int)(q.X1 - q.X0), (int)(q.Y1 - q.Y0)));
 				prevGlyph = glyph;

--- a/src/FontStashSharp/SpriteFontBase.cs
+++ b/src/FontStashSharp/SpriteFontBase.cs
@@ -71,8 +71,7 @@ namespace FontStashSharp
 					continue;
 				}
 
-				// For rendering we switch to a glyph which has a higher resolution but needs to be rendered at the same position
-				// now we just need to do some correct scaling, such that he font isn't twice the size on the screen ;)
+
 				var glyph = GetGlyph(codepoint, false);
 				if (glyph == null)
 				{
@@ -272,8 +271,6 @@ namespace FontStashSharp
 				}
 
 				GetQuad(glyph, prevGlyph, scale, ref originX, ref originY, ref q);
-
-
 				if (!glyph.IsEmpty)
 				{
 					var sourceRect = new Rectangle((int)q.S0, (int)q.T0, (int)(q.S1 - q.S0), (int)(q.T1 - q.T0));

--- a/src/FontStashSharp/SpriteFontBase.cs
+++ b/src/FontStashSharp/SpriteFontBase.cs
@@ -31,7 +31,7 @@ namespace FontStashSharp
 			RenderFontSize = fontSize * 4;
 		}
 
-		protected internal abstract FontGlyph GetGlyph(int codepoint, bool withoutBitmap, bool isForRendering);
+		protected internal abstract FontGlyph GetGlyph(int codepoint, bool withoutBitmap);
 		protected abstract void PreDraw(string str, out float ascent, out float lineHeight);
 
 		/// <summary>
@@ -73,7 +73,7 @@ namespace FontStashSharp
 
 				// For rendering we switch to a glyph which has a higher resolution but needs to be rendered at the same position
 				// now we just need to do some correct scaling, such that he font isn't twice the size on the screen ;)
-				var glyph = GetGlyph(codepoint, false, true);
+				var glyph = GetGlyph(codepoint, false);
 				if (glyph == null)
 				{
 					continue;
@@ -168,9 +168,7 @@ namespace FontStashSharp
 					continue;
 				}
 
-				// For rendering we switch to a glyph which has a higher resolution but needs to be rendered at the same position
-				// now we just need to do some correct scaling, such that he font isn't twice the size on the screen ;)
-				var glyph = GetGlyph(codepoint, false, true);
+				var glyph = GetGlyph(codepoint, false);
 				if (glyph == null)
 				{
 					++pos;
@@ -267,7 +265,7 @@ namespace FontStashSharp
 					continue;
 				}
 
-				var glyph = GetGlyph(codepoint, false, true);
+				var glyph = GetGlyph(codepoint, false);
 				if (glyph == null)
 				{
 					continue;
@@ -363,7 +361,7 @@ namespace FontStashSharp
 					continue;
 				}
 
-				var glyph = GetGlyph(codepoint, false, true);
+				var glyph = GetGlyph(codepoint, false);
 				if (glyph == null)
 				{
 					++pos;
@@ -450,7 +448,7 @@ namespace FontStashSharp
 					continue;
 				}
 
-				var glyph = GetGlyph(codepoint, true, true);
+				var glyph = GetGlyph(codepoint, true);
 				if (glyph == null)
 				{
 					continue;
@@ -517,7 +515,7 @@ namespace FontStashSharp
 					continue;
 				}
 
-				var glyph = GetGlyph(codepoint, true, true);
+				var glyph = GetGlyph(codepoint, true);
 				if (glyph == null)
 				{
 					continue;
@@ -581,7 +579,7 @@ namespace FontStashSharp
 					continue;
 				}
 
-				var glyph = GetGlyph(codepoint, true, true);
+				var glyph = GetGlyph(codepoint, true);
 				if (glyph == null)
 				{
 					continue;
@@ -634,13 +632,13 @@ namespace FontStashSharp
 					continue;
 				}
 
-				var glyph = GetGlyph(codepoint, true, false);
+				var glyph = GetGlyph(codepoint, true);
 				if (glyph == null)
 				{
 					continue;
 				}
 
-				GetQuad(glyph, prevGlyph, glyph, prevGlyph, scale, ref x, ref y, ref q);
+				GetQuad(glyph, prevGlyph, scale, ref x, ref y, ref q);
 
 				Rects.Add(new Rectangle((int)q.X0, (int)q.Y0, (int)(q.X1 - q.X0), (int)(q.Y1 - q.Y0)));
 				prevGlyph = glyph;

--- a/src/FontStashSharp/StaticSpriteFont.cs
+++ b/src/FontStashSharp/StaticSpriteFont.cs
@@ -78,13 +78,13 @@ namespace FontStashSharp
 			return result;
 		}
 
-		protected override void PreDraw(string str, out float ascent, out float lineHeight)
+		protected override void PreDraw(string str, out float ascent, out float lineHeight, bool isForMeasurement)
 		{
 			ascent = 0;
 			lineHeight = FontSize + LineSpacing;
 		}
 
-		protected override void PreDraw(StringBuilder str, out float ascent, out float lineHeight)
+		protected override void PreDraw(StringBuilder str, out float ascent, out float lineHeight, bool isForMeasurement)
 		{
 			ascent = 0;
 			lineHeight = FontSize + LineSpacing;

--- a/src/FontStashSharp/StaticSpriteFont.cs
+++ b/src/FontStashSharp/StaticSpriteFont.cs
@@ -68,7 +68,7 @@ namespace FontStashSharp
 			return result;
 		}
 
-		protected internal override FontGlyph GetGlyph(int codepoint, bool withoutBitmap)
+		protected internal override FontGlyph GetGlyph(int codepoint, bool withoutBitmap, bool isForRendering)
 		{
 			var result = InternalGetGlyph(codepoint);
 			if (result == null && DefaultCharacter != null)
@@ -122,7 +122,7 @@ namespace FontStashSharp
 				x += CharacterSpacing;
 			}
 
-			base.GetQuad(glyph, prevGlyph, scale, ref x, ref y, ref q);
+			base.GetQuad(glyph, prevGlyph, glyph, prevGlyph, scale, ref x, ref y, ref q);
 		}
 
 		private static BitmapFont LoadBMFont(string data)

--- a/src/FontStashSharp/StaticSpriteFont.cs
+++ b/src/FontStashSharp/StaticSpriteFont.cs
@@ -70,7 +70,7 @@ namespace FontStashSharp
 			return result;
 		}
 
-		protected internal override FontGlyph GetGlyph(int codepoint, bool withoutBitmap)
+		protected internal override FontGlyph GetGlyph(int codepoint, bool withoutBitmap, bool isForMeasurement)
 		{
 			var result = InternalGetGlyph(codepoint);
 			if (result == null && DefaultCharacter != null)

--- a/src/FontStashSharp/StaticSpriteFont.cs
+++ b/src/FontStashSharp/StaticSpriteFont.cs
@@ -56,7 +56,9 @@ namespace FontStashSharp
 
 		public bool UseKernings { get; set; } = true;
 
-		public StaticSpriteFont(int fontSize): base(fontSize) {}
+		public StaticSpriteFont(int fontSize): base(fontSize)
+		{
+		}
 
 		private FontGlyph InternalGetGlyph(int codepoint)
 		{

--- a/src/FontStashSharp/StaticSpriteFont.cs
+++ b/src/FontStashSharp/StaticSpriteFont.cs
@@ -68,7 +68,7 @@ namespace FontStashSharp
 			return result;
 		}
 
-		protected internal override FontGlyph GetGlyph(int codepoint, bool withoutBitmap, bool isForRendering)
+		protected internal override FontGlyph GetGlyph(int codepoint, bool withoutBitmap)
 		{
 			var result = InternalGetGlyph(codepoint);
 			if (result == null && DefaultCharacter != null)
@@ -122,7 +122,7 @@ namespace FontStashSharp
 				x += CharacterSpacing;
 			}
 
-			base.GetQuad(glyph, prevGlyph, glyph, prevGlyph, scale, ref x, ref y, ref q);
+			base.GetQuad(glyph, prevGlyph, scale, ref x, ref y, ref q);
 		}
 
 		private static BitmapFont LoadBMFont(string data)

--- a/src/FontStashSharp/StaticSpriteFont.cs
+++ b/src/FontStashSharp/StaticSpriteFont.cs
@@ -58,6 +58,8 @@ namespace FontStashSharp
 
 		public StaticSpriteFont(int fontSize): base(fontSize)
 		{
+			//RenderFontSize = FontSize;
+			RenderFontSizeMultiplicator = 1;
 		}
 
 		private FontGlyph InternalGetGlyph(int codepoint)
@@ -81,13 +83,13 @@ namespace FontStashSharp
 		protected override void PreDraw(string str, out float ascent, out float lineHeight, bool isForMeasurement)
 		{
 			ascent = 0;
-			lineHeight = FontSize + LineSpacing;
+			lineHeight = (isForMeasurement ? FontSize : FontSize * RenderFontSizeMultiplicator) + LineSpacing;
 		}
 
 		protected override void PreDraw(StringBuilder str, out float ascent, out float lineHeight, bool isForMeasurement)
 		{
 			ascent = 0;
-			lineHeight = FontSize + LineSpacing;
+			lineHeight = (isForMeasurement ? FontSize : FontSize * RenderFontSizeMultiplicator) + LineSpacing;
 		}
 
 		private static int KerningKey(int codepoint1, int codepoint2)

--- a/src/FontStashSharp/StaticSpriteFont.cs
+++ b/src/FontStashSharp/StaticSpriteFont.cs
@@ -56,11 +56,7 @@ namespace FontStashSharp
 
 		public bool UseKernings { get; set; } = true;
 
-		public StaticSpriteFont(int fontSize): base(fontSize)
-		{
-			//RenderFontSize = FontSize;
-			RenderFontSizeMultiplicator = 1;
-		}
+		public StaticSpriteFont(int fontSize): base(fontSize) {}
 
 		private FontGlyph InternalGetGlyph(int codepoint)
 		{
@@ -70,7 +66,7 @@ namespace FontStashSharp
 			return result;
 		}
 
-		protected internal override FontGlyph GetGlyph(int codepoint, bool withoutBitmap, bool isForMeasurement)
+		protected internal override FontGlyph GetGlyph(int codepoint, bool withoutBitmap)
 		{
 			var result = InternalGetGlyph(codepoint);
 			if (result == null && DefaultCharacter != null)
@@ -80,16 +76,16 @@ namespace FontStashSharp
 			return result;
 		}
 
-		protected override void PreDraw(string str, out float ascent, out float lineHeight, bool isForMeasurement)
+		protected override void PreDraw(string str, out float ascent, out float lineHeight, bool withoutBitmap)
 		{
 			ascent = 0;
-			lineHeight = (isForMeasurement ? FontSize : FontSize * RenderFontSizeMultiplicator) + LineSpacing;
+			lineHeight = FontSize + LineSpacing;
 		}
 
-		protected override void PreDraw(StringBuilder str, out float ascent, out float lineHeight, bool isForMeasurement)
+		protected override void PreDraw(StringBuilder str, out float ascent, out float lineHeight, bool withoutBitmap)
 		{
 			ascent = 0;
-			lineHeight = (isForMeasurement ? FontSize : FontSize * RenderFontSizeMultiplicator) + LineSpacing;
+			lineHeight = FontSize + LineSpacing;
 		}
 
 		private static int KerningKey(int codepoint1, int codepoint2)

--- a/src/FontStashSharp/StbTrueTypeSharpFontLoader/StbTrueTypeSharpFontSource.cs
+++ b/src/FontStashSharp/StbTrueTypeSharpFontLoader/StbTrueTypeSharpFontSource.cs
@@ -5,7 +5,7 @@ using static StbTrueTypeSharp.StbTrueType;
 
 namespace FontStashSharp
 {
-	internal unsafe class StbTrueTypeSharpFontSource: IDynamicFontSource
+	internal unsafe class StbTrueTypeSharpFontSource: IFontSource
 	{
 		private int? _lastSize;
 		private GCHandle? dataPtr = null;
@@ -93,25 +93,17 @@ namespace FontStashSharp
 			y1 = y1Temp;
 		}
 
-		public void RasterizeGlyphBitmap(int glyphId, int fontSize, byte[] buffer, int startIndex, int outWidth, int outHeight, int outStride)
+		public void RasterizeGlyphBitmap(int glyphId, int fontSize, byte[] buffer, int startIndex, int outWidth, int outHeight, int outStride, int kernelWidth, int kernelHeight)
 		{
 			UpdateSize(fontSize);
 
 			fixed (byte* output = &buffer[startIndex])
 			{
 				stbtt_MakeGlyphBitmap(_font, output, outWidth, outHeight, outStride, Scale, Scale, glyphId);
-			}
-		}
-
-		public void RasterizeGlyphBitmap(int glyphId, int fontSize, byte[] buffer, int startIndex, int outWidth, int outHeight, int outStride, uint kernelWidth)
-		{
-			UpdateSize(fontSize);
-
-			fixed (byte* output = &buffer[startIndex])
-			{
-				stbtt_MakeGlyphBitmap(_font, output, outWidth, outHeight, outStride, Scale, Scale, glyphId);
-				stbtt__h_prefilter(output, outWidth, outHeight, outStride, kernelWidth);
-				stbtt__v_prefilter(output, outWidth, outHeight, outStride, kernelWidth);
+				if(kernelWidth > 0)
+					stbtt__v_prefilter(output, outWidth, outHeight, outStride, (uint)kernelWidth);
+				if(kernelHeight > 0)
+					stbtt__h_prefilter(output, outWidth, outHeight, outStride, (uint)kernelHeight);
 			}
 		}
 

--- a/src/FontStashSharp/StbTrueTypeSharpFontLoader/StbTrueTypeSharpFontSource.cs
+++ b/src/FontStashSharp/StbTrueTypeSharpFontLoader/StbTrueTypeSharpFontSource.cs
@@ -5,7 +5,7 @@ using static StbTrueTypeSharp.StbTrueType;
 
 namespace FontStashSharp
 {
-	internal unsafe class StbTrueTypeSharpFontSource: IFontSource
+	internal unsafe class StbTrueTypeSharpFontSource: IDynamicFontSource
 	{
 		private int? _lastSize;
 		private GCHandle? dataPtr = null;
@@ -100,6 +100,18 @@ namespace FontStashSharp
 			fixed (byte* output = &buffer[startIndex])
 			{
 				stbtt_MakeGlyphBitmap(_font, output, outWidth, outHeight, outStride, Scale, Scale, glyphId);
+			}
+		}
+
+		public void RasterizeGlyphBitmap(int glyphId, int fontSize, byte[] buffer, int startIndex, int outWidth, int outHeight, int outStride, uint kernelWidth)
+		{
+			UpdateSize(fontSize);
+
+			fixed (byte* output = &buffer[startIndex])
+			{
+				stbtt_MakeGlyphBitmap(_font, output, outWidth, outHeight, outStride, Scale, Scale, glyphId);
+				stbtt__h_prefilter(output, outWidth, outHeight, outStride, kernelWidth);
+				stbtt__v_prefilter(output, outWidth, outHeight, outStride, kernelWidth);
 			}
 		}
 


### PR DESCRIPTION
This is still wip because unfortunately there is still a bug inside the measurement methods. So far I was not able to figure it out yet.

In the rendered output of the test project one can see that the bounds are still slightly calculated wrong:
![image](https://user-images.githubusercontent.com/25414896/122653388-6193f580-d144-11eb-9b38-1fac3f29f401.png)

If someone wants to help me out fixing this, I would be very happy.

PS:
I'm aware that the changes which add another glyph map within the `DynamicSpriteFont` are not necessary anymore. I just did not find time yet to remove it.

EDIT:

This fixes #15 