### PR TITLE
Fix FNA.Core compatibility from 23.12

### DIFF
--- a/src/XNA/FontStashSharp.FNA.Core.csproj
+++ b/src/XNA/FontStashSharp.FNA.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <PackageId>FontStashSharp.FNA</PackageId>
     <AssemblyName>FontStashSharp.FNA</AssemblyName>
     <Description>FontStashSharp for FNA.Core</Description>


### PR DESCRIPTION
FNA has dropped .NET Standard compatibility as per FNA-XNA/FNA#453, making FontStashSharp.FNA.Core.csproj not buildable with FNA >=23.12

This PR upgrades the project to .NET 7.0, allowing FontStashSharp to be built again and still work just fine.