### PR TITLE
Remove `ref` restriction to allow `StringSegment` being a field of class.

### DIFF
--- a/src/FontStashSharp/StringSegment.cs
+++ b/src/FontStashSharp/StringSegment.cs
@@ -2,7 +2,7 @@
 
 namespace FontStashSharp
 {
-	public readonly ref struct StringSegment
+	public readonly struct StringSegment
 	{
 		public readonly string String;
 		public readonly int Offset;


### PR DESCRIPTION
`StringSegment` has no byref like fields(like a managed pointer pointed to stack) that prevents it to be stored on managed heap. 
Instead, it stores a string reference, therefore this struct is more similar to `System.ReadOnlyMemory<char>` instead of the Span brother.  We can make it becomes a regular struct to have more capabilities, for example, become a field of `class RichTextLayout`.