### PR TITLE
Add text shaping via HarfBuzzSharp and BiDi support

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,3 +57,4 @@ Stroked Text:
 * [FreeTypeSharp](https://github.com/ryancheung/FreeTypeSharp)
 * [SixLabors.Fonts](https://github.com/SixLabors/Fonts)
 * [TrippyGL](https://github.com/SilkCommunity/TrippyGL)
+* [HarfBuzzSharp](https://www.nuget.org/packages/HarfBuzzSharp/)

--- a/src/FontStashSharp.Tests/HarfBuzzTests.cs
+++ b/src/FontStashSharp.Tests/HarfBuzzTests.cs
@@ -1,0 +1,184 @@
+using FontStashSharp.HarfBuzz;
+using NUnit.Framework;
+
+namespace FontStashSharp.Tests
+{
+	[TestFixture]
+	public class HarfBuzzTests
+	{
+		[TestCase("Hello World", 1, TextDirection.LTR)]
+		[TestCase("مرحبا", 1, TextDirection.RTL)]
+		[TestCase("", 0, TextDirection.LTR)]
+		[TestCase("123", 1, TextDirection.LTR)]
+		public void BiDiAnalyzer_SingleDirectionText(string text, int expectedRunCount, TextDirection expectedDirection)
+		{
+			var runs = BiDiAnalyzer.SegmentIntoDirectionalRuns(text);
+
+			Assert.That(runs.Count, Is.EqualTo(expectedRunCount));
+
+			if (expectedRunCount > 0)
+			{
+				Assert.That(runs[0].Direction, Is.EqualTo(expectedDirection));
+				Assert.That(runs[0].Start, Is.EqualTo(0));
+				Assert.That(runs[0].Length, Is.EqualTo(text.Length));
+			}
+		}
+
+		[Test]
+		public void BiDiAnalyzer_MixedLtrRtlText()
+		{
+			// English "Hello" + Arabic "مرحبا"
+			var text = "Hello مرحبا";
+			var runs = BiDiAnalyzer.SegmentIntoDirectionalRuns(text);
+
+			// Should have 2 runs: LTR for "Hello " and RTL for "مرحبا"
+			Assert.That(runs.Count, Is.EqualTo(2));
+
+			Assert.That(runs[0].Direction, Is.EqualTo(TextDirection.LTR));
+			Assert.That(runs[0].Start, Is.EqualTo(0));
+			Assert.That(runs[1].Direction, Is.EqualTo(TextDirection.RTL));
+		}
+
+		[Test]
+		public void BiDiAnalyzer_LeadingNeutralCharacters()
+		{
+			// Spaces before text should be assigned to the following run's direction
+			var text = "  Hello";
+			var runs = BiDiAnalyzer.SegmentIntoDirectionalRuns(text);
+
+			Assert.That(runs.Count, Is.EqualTo(1));
+			Assert.That(runs[0].Direction, Is.EqualTo(TextDirection.LTR));
+			Assert.That(runs[0].Start, Is.EqualTo(0));
+			Assert.That(runs[0].Length, Is.EqualTo(text.Length));
+		}
+
+		[Test]
+		public void BiDiAnalyzer_OnlyNeutralCharacters()
+		{
+			// Text with only neutral characters should default to LTR
+			var text = "   ...   ";
+			var runs = BiDiAnalyzer.SegmentIntoDirectionalRuns(text);
+
+			Assert.That(runs.Count, Is.EqualTo(1));
+			Assert.That(runs[0].Direction, Is.EqualTo(TextDirection.LTR));
+		}
+
+		[Test]
+		public void TextShaper_EmptyString()
+		{
+			var settings = new FontSystemSettings { UseTextShaping = true };
+			var fontSystem = TestsEnvironment.CreateDefaultFontSystem(settings);
+
+			var shaped = TextShaper.Shape(fontSystem, "", 32);
+
+			Assert.That(shaped, Is.Not.Null);
+			Assert.That(shaped.Glyphs, Is.Not.Null);
+			Assert.That(shaped.Glyphs.Length, Is.EqualTo(0));
+			Assert.That(shaped.OriginalText, Is.EqualTo(""));
+		}
+
+		[Test]
+		public void TextShaper_NullString()
+		{
+			var settings = new FontSystemSettings { UseTextShaping = true };
+			var fontSystem = TestsEnvironment.CreateDefaultFontSystem(settings);
+
+			var shaped = TextShaper.Shape(fontSystem, null, 32);
+
+			Assert.That(shaped, Is.Not.Null);
+			Assert.That(shaped.Glyphs, Is.Not.Null);
+			Assert.That(shaped.Glyphs.Length, Is.EqualTo(0));
+			Assert.That(shaped.OriginalText, Is.EqualTo(""));
+		}
+
+		[Test]
+		public void TextShaper_SimpleText()
+		{
+			// Create font system with BiDi disabled but text shaping enabled
+			var settings = new FontSystemSettings { UseTextShaping = true, EnableBiDi = false };
+			var fontSystem = TestsEnvironment.CreateDefaultFontSystem(settings);
+
+			var shaped = TextShaper.Shape(fontSystem, "Hello", 32);
+
+			Assert.That(shaped, Is.Not.Null);
+			Assert.That(shaped.Glyphs, Is.Not.Null);
+			Assert.That(shaped.Glyphs.Length, Is.GreaterThan(0));
+			Assert.That(shaped.OriginalText, Is.EqualTo("Hello"));
+			Assert.That(shaped.FontSize, Is.EqualTo(32));
+
+			// Each glyph should have valid advance values
+			foreach (var glyph in shaped.Glyphs)
+			{
+				Assert.That(glyph.XAdvance, Is.GreaterThan(0));
+			}
+		}
+
+		[Test]
+		public void TextShaper_WithBiDiEnabled()
+		{
+			// Create font system with BiDi enabled
+			var settings = new FontSystemSettings { UseTextShaping = true, EnableBiDi = true };
+			var fontSystem = TestsEnvironment.CreateDefaultFontSystem(settings);
+
+			var shaped = TextShaper.Shape(fontSystem, "Test", 32);
+
+			Assert.That(shaped, Is.Not.Null);
+			Assert.That(shaped.Glyphs, Is.Not.Null);
+			Assert.That(shaped.Glyphs.Length, Is.GreaterThan(0));
+			Assert.That(shaped.OriginalText, Is.EqualTo("Test"));
+		}
+
+		[Test]
+		public void TextShaper_SurrogatePair_FormsSingleCluster()
+		{
+			var fontSystem = TestsEnvironment.CreateDefaultFontSystem(new FontSystemSettings { UseTextShaping = true });
+			var text = "😀"; // U+1F600 (surrogate pair)
+			var shaped = TextShaper.Shape(fontSystem, text, 32);
+
+			Assert.That(shaped.Glyphs.Length, Is.LessThanOrEqualTo(1), "Emoji surrogate pair should form a single cluster");
+		}
+
+		[Test]
+		public void TextShaper_EmojiZWJSequence()
+		{
+			var settings = new FontSystemSettings { UseTextShaping = true };
+			var fontSystem = TestsEnvironment.CreateDefaultFontSystem(settings);
+
+			// Family: 👨‍👩‍👧‍👦 (multiple codepoints joined by ZWJ)
+			var text = "👨‍👩‍👧‍👦";
+			var shaped = TextShaper.Shape(fontSystem, text, 32);
+
+			Assert.That(shaped.Glyphs.Length, Is.LessThan(text.Length),
+					"ZWJ sequences should combine into fewer glyphs");
+		}
+
+		[Test]
+		public void ShapedText_PreservesOriginalText()
+		{
+			var settings = new FontSystemSettings { UseTextShaping = true };
+			var fontSystem = TestsEnvironment.CreateDefaultFontSystem(settings);
+			var originalText = "Testing 123";
+
+			var shaped = TextShaper.Shape(fontSystem, originalText, 32);
+
+			Assert.That(shaped.OriginalText, Is.EqualTo(originalText));
+		}
+
+		[Test]
+		public void ShapedGlyphs_HaveValidClusterIndices()
+		{
+			var settings = new FontSystemSettings { UseTextShaping = true };
+			var fontSystem = TestsEnvironment.CreateDefaultFontSystem(settings);
+			var text = "Hello";
+
+			var shaped = TextShaper.Shape(fontSystem, text, 32);
+
+			// All cluster indices should be within the text length
+			foreach (var glyph in shaped.Glyphs)
+			{
+				Assert.That(glyph.Cluster, Is.GreaterThanOrEqualTo(0));
+				Assert.That(glyph.Cluster, Is.LessThan(text.Length));
+			}
+		}
+	}
+}

--- a/src/FontStashSharp/DynamicSpriteFont.cs
+++ b/src/FontStashSharp/DynamicSpriteFont.cs
@@ -1,5 +1,6 @@
 ﻿using FontStashSharp.Interfaces;
 using System;
+using System.Collections.Generic;
 
 #if MONOGAME || FNA
 using Microsoft.Xna.Framework;
@@ -19,14 +20,105 @@ namespace FontStashSharp
 		private class GlyphStorage
 		{
 			public Int32Map<DynamicFontGlyph> Glyphs = new Int32Map<DynamicFontGlyph>();
+			public Int32Map<DynamicFontGlyph> ShapedGlyphs = new Int32Map<DynamicFontGlyph>();
 			public FontSystemEffect Effect;
 			public int EffectAmount;
+		}
+
+		private struct ShapedTextCacheKey : IEquatable<ShapedTextCacheKey>
+		{
+			public readonly string Text;
+			public readonly float FontSize;
+
+			public ShapedTextCacheKey(string text, float fontSize)
+			{
+				Text = text;
+				FontSize = fontSize;
+			}
+
+			public bool Equals(ShapedTextCacheKey other)
+			{
+				return Text == other.Text && FontSize.Equals(other.FontSize);
+			}
+
+			public override bool Equals(object obj)
+			{
+				return obj is ShapedTextCacheKey other && Equals(other);
+			}
+
+			public override int GetHashCode()
+			{
+				unchecked
+				{
+					return ((Text?.GetHashCode() ?? 0) * 397) ^ FontSize.GetHashCode();
+				}
+			}
+		}
+
+		private class ShapedTextCache
+		{
+			private readonly Dictionary<ShapedTextCacheKey, LinkedListNode<(ShapedTextCacheKey Key, HarfBuzz.ShapedText Value)>> _cache =
+				new Dictionary<ShapedTextCacheKey, LinkedListNode<(ShapedTextCacheKey Key, HarfBuzz.ShapedText Value)>>();
+			private readonly LinkedList<(ShapedTextCacheKey Key, HarfBuzz.ShapedText Value)> _lruList =
+				new LinkedList<(ShapedTextCacheKey Key, HarfBuzz.ShapedText Value)>();
+			private readonly int _maxCacheEntries;
+
+			public ShapedTextCache(int maxCacheEntries)
+			{
+				_maxCacheEntries = maxCacheEntries;
+			}
+
+			public bool TryGet(ShapedTextCacheKey key, out HarfBuzz.ShapedText shapedText)
+			{
+				if (_cache.TryGetValue(key, out var node))
+				{
+					// Move to front (most recently used)
+					_lruList.Remove(node);
+					_lruList.AddFirst(node);
+					shapedText = node.Value.Value;
+					return true;
+				}
+
+				shapedText = null;
+				return false;
+			}
+
+			public void Add(ShapedTextCacheKey key, HarfBuzz.ShapedText shapedText)
+			{
+				// Check if already exists
+				if (_cache.ContainsKey(key))
+				{
+					return;
+				}
+
+				// Evict oldest entry if cache is full
+				if (_cache.Count >= _maxCacheEntries)
+				{
+					var oldest = _lruList.Last;
+					if (oldest != null)
+					{
+						_cache.Remove(oldest.Value.Key);
+						_lruList.RemoveLast();
+					}
+				}
+
+				// Add new entry
+				var node = _lruList.AddFirst((key, shapedText));
+				_cache[key] = node;
+			}
+
+			public void Clear()
+			{
+				_cache.Clear();
+				_lruList.Clear();
+			}
 		}
 
 		private readonly Int32Map<GlyphStorage> _storages = new Int32Map<GlyphStorage>();
 		private GlyphStorage _lastStorage;
 		private readonly Int32Map<int> Kernings = new Int32Map<int>();
 		private FontMetrics[] IndexedMetrics;
+		private readonly ShapedTextCache _shapedTextCache;
 
 		public FontSystem FontSystem { get; private set; }
 
@@ -39,13 +131,20 @@ namespace FontStashSharp
 
 			FontSystem = system;
 			RenderFontSizeMultiplicator = FontSystem.FontResolutionFactor;
+
+			_shapedTextCache = new ShapedTextCache(system.ShapedTextCacheSize);
 		}
 
 		internal Int32Map<DynamicFontGlyph> GetGlyphs(FontSystemEffect effect, int effectAmount)
 		{
+			return GetGlyphStorage(effect, effectAmount).Glyphs;
+		}
+
+		private GlyphStorage GetGlyphStorage(FontSystemEffect effect, int effectAmount)
+		{
 			if (_lastStorage != null && _lastStorage.Effect == effect && _lastStorage.EffectAmount == effectAmount)
 			{
-				return _lastStorage.Glyphs;
+				return _lastStorage;
 			}
 
 			var key = (int)effect << 16 | effectAmount;
@@ -64,7 +163,7 @@ namespace FontStashSharp
 
 			_lastStorage = result;
 
-			return result.Glyphs;
+			return result;
 		}
 
 		private DynamicFontGlyph GetGlyphWithoutBitmap(int codepoint, FontSystemEffect effect, int effectAmount)
@@ -155,6 +254,69 @@ namespace FontStashSharp
 			return result;
 		}
 
+		/// <summary>
+		/// Get a glyph by its glyph ID
+		/// </summary>
+#if MONOGAME || FNA || STRIDE
+		internal DynamicFontGlyph GetGlyphByGlyphId(GraphicsDevice device, int glyphId, int fontSourceIndex, FontSystemEffect effect, int effectAmount)
+#else
+		internal DynamicFontGlyph GetGlyphByGlyphId(ITexture2DManager device, int glyphId, int fontSourceIndex, FontSystemEffect effect, int effectAmount)
+#endif
+		{
+			if (effect == FontSystemEffect.None)
+			{
+			}
+			else if (effectAmount == 0)
+			{
+				effect = FontSystemEffect.None;
+			}
+
+			var storage = GetGlyphStorage(effect, effectAmount);
+
+			var key = (fontSourceIndex << 24) | glyphId;
+
+			DynamicFontGlyph glyph;
+			if (storage.ShapedGlyphs.TryGetValue(key, out glyph))
+			{
+				if (device != null && glyph.Texture == null)
+				{
+					FontSystem.RenderGlyphOnAtlas(device, glyph);
+				}
+				return glyph;
+			}
+
+			var fontSize = FontSize * FontSystem.FontResolutionFactor;
+			var font = FontSystem.FontSources[fontSourceIndex];
+
+			int advance, x0, y0, x1, y1;
+			font.GetGlyphMetrics(glyphId, fontSize, out advance, out x0, out y0, out x1, out y1);
+
+			var gw = x1 - x0 + effectAmount * 2;
+			var gh = y1 - y0 + effectAmount * 2;
+
+			glyph = new DynamicFontGlyph
+			{
+				Codepoint = 0, // Not applicable for shaped glyphs
+				Id = glyphId,
+				FontSize = fontSize,
+				FontSourceIndex = fontSourceIndex,
+				RenderOffset = new Point(x0, y0),
+				Size = new Point(gw, gh),
+				XAdvance = advance,
+				Effect = effect,
+				EffectAmount = effectAmount
+			};
+
+			storage.ShapedGlyphs[key] = glyph;
+
+			if (device != null && glyph.Texture == null)
+			{
+				FontSystem.RenderGlyphOnAtlas(device, glyph);
+			}
+
+			return glyph;
+		}
+
 #if MONOGAME || FNA || STRIDE
 		protected internal override FontGlyph GetGlyph(GraphicsDevice device, int codepoint, FontSystemEffect effect, int effectAmount)
 #else
@@ -217,6 +379,11 @@ namespace FontStashSharp
 			if (source.IsNull)
 				return Bounds.Empty;
 
+			if (FontSystem.UseTextShaping)
+			{
+				return InternalShapedTextBounds(source, position, characterSpacing, lineSpacing, effect, effectAmount);
+			}
+
 			var result = base.InternalTextBounds(source, position, characterSpacing, lineSpacing, effect, effectAmount);
 			if (effect != FontSystemEffect.None)
 			{
@@ -224,6 +391,96 @@ namespace FontStashSharp
 			}
 
 			return result;
+		}
+
+		private Bounds InternalShapedTextBounds(TextSource source, Vector2 position,
+			float characterSpacing, float lineSpacing, FontSystemEffect effect, int effectAmount)
+		{
+			var text = source.StringText.String ?? source.StringBuilderText?.ToString();
+			if (string.IsNullOrEmpty(text))
+			{
+				return Bounds.Empty;
+			}
+
+			var lines = text.Split('\n');
+
+			int ascent = 0, lineHeight = 0;
+			if (FontSystem.FontSources.Count > 0)
+			{
+				int descent, lh;
+				FontSystem.FontSources[0].GetMetricsForSize(FontSize * FontSystem.FontResolutionFactor, out ascent, out descent, out lh);
+				lineHeight = lh;
+			}
+
+			var x = position.X;
+			var y = position.Y + ascent;
+
+			float minx = x, maxx = x, miny = y, maxy = y;
+
+			for (int lineIndex = 0; lineIndex < lines.Length; lineIndex++)
+			{
+				var line = lines[lineIndex];
+
+				if (lineIndex > 0)
+				{
+					x = position.X;
+					y += lineHeight + lineSpacing;
+				}
+
+				if (string.IsNullOrEmpty(line))
+				{
+					continue;
+				}
+
+				var shapedText = GetShapedText(line, FontSize * FontSystem.FontResolutionFactor);
+
+				float lineStartX = x;
+				for (int i = 0; i < shapedText.Glyphs.Length; i++)
+				{
+					var shapedGlyph = shapedText.Glyphs[i];
+
+					if (i > 0 && characterSpacing > 0)
+					{
+						x += characterSpacing;
+					}
+
+					var glyph = GetGlyphByGlyphId(null, shapedGlyph.GlyphId, shapedGlyph.FontSourceIndex, effect, effectAmount);
+
+					if (glyph != null)
+					{
+						var glyphX = x + glyph.RenderOffset.X + (shapedGlyph.XOffset / 64.0f);
+						var glyphY = y + glyph.RenderOffset.Y + (shapedGlyph.YOffset / 64.0f);
+						var glyphX2 = glyphX + glyph.Size.X;
+						var glyphY2 = glyphY + glyph.Size.Y;
+
+						if (glyphX < minx) minx = glyphX;
+						if (glyphY < miny) miny = glyphY;
+						if (glyphX2 > maxx) maxx = glyphX2;
+						if (glyphY2 > maxy) maxy = glyphY2;
+					}
+
+					if (glyph != null)
+					{
+						x += glyph.XAdvance;
+						y += (shapedGlyph.YAdvance / 64.0f);
+					}
+					else
+					{
+						// Fallback
+						x += (shapedGlyph.XAdvance / 64.0f);
+						y += (shapedGlyph.YAdvance / 64.0f);
+					}
+				}
+
+				if (x > maxx) maxx = x;
+			}
+
+			if (effect != FontSystemEffect.None)
+			{
+				maxx += effectAmount * 2;
+			}
+
+			return new Bounds(minx, miny, maxx, maxy);
 		}
 
 		private static int GetKerningsKey(int glyph1, int glyph2)
@@ -257,6 +514,41 @@ namespace FontStashSharp
 			}
 
 			return result;
+		}
+
+		/// <summary>
+		/// Shape text using HarfBuzz with caching
+		/// </summary>
+		internal HarfBuzz.ShapedText GetShapedText(string text, float fontSize)
+		{
+			if (string.IsNullOrEmpty(text))
+			{
+				return new HarfBuzz.ShapedText
+				{
+					Glyphs = new HarfBuzz.ShapedGlyph[0],
+					OriginalText = text ?? string.Empty,
+					FontSize = fontSize
+				};
+			}
+
+			var cacheKey = new ShapedTextCacheKey(text, fontSize);
+			if (_shapedTextCache.TryGet(cacheKey, out var cachedResult))
+			{
+				return cachedResult;
+			}
+
+			var shapedText = FontSystem.ShapeText(text, fontSize);
+			_shapedTextCache.Add(cacheKey, shapedText);
+
+			return shapedText;
+		}
+
+		/// <summary>
+		/// Clear the shaped text cache
+		/// </summary>
+		internal void ClearShapedTextCache()
+		{
+			_shapedTextCache.Clear();
 		}
 	}
 }

--- a/src/FontStashSharp/FontStashSharp.PlatformAgnostic.csproj
+++ b/src/FontStashSharp/FontStashSharp.PlatformAgnostic.csproj
@@ -13,6 +13,7 @@
     <PackageReference Include="FontStashSharp.Base" Version="$(FontStashSharpBaseVersion)" />
     <PackageReference Include="FontStashSharp.Rasterizers.StbTrueTypeSharp" Version="$(FontStashSharpBaseVersion)" />
     <PackageReference Include="Cyotek.Drawing.BitmapFont" Version="$(CyotekDrawingBitmapFontVersion)" />
+    <PackageReference Include="HarfBuzzSharp" Version="8.3.1.2" />
     <PackageReference Include="StbImageSharp" Version="$(StbImageSharpVersion)" />
     <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />
   </ItemGroup>

--- a/src/FontStashSharp/FontSystemDefaults.cs
+++ b/src/FontStashSharp/FontSystemDefaults.cs
@@ -8,6 +8,7 @@ namespace FontStashSharp
 		private static int _textureWidth = 1024, _textureHeight = 1024;
 		private static float _fontResolutionFactor = 1.0f;
 		private static int _kernelWidth = 0, _kernelHeight = 0;
+		private static int _shapedTextCacheSize = 100;
 
 		public static int TextureWidth
 		{
@@ -99,5 +100,24 @@ namespace FontStashSharp
 		public static int? DefaultCharacter { get; set; } = ' ';
 
 		public static int TextStyleLineHeight { get; set; } = 2;
+
+		/// <summary>
+		/// Maximum number of entries in the shaped text cache (for HarfBuzz text shaping)
+		/// Higher values use more memory but reduce shaping overhead for repeated text
+		/// Default: 100
+		/// </summary>
+		public static int ShapedTextCacheSize
+		{
+			get => _shapedTextCacheSize;
+			set
+			{
+				if (value < 1)
+				{
+					throw new ArgumentOutOfRangeException(nameof(value), value, "Cache size must be at least 1");
+				}
+
+				_shapedTextCacheSize = value;
+			}
+		}
 	}
 }

--- a/src/FontStashSharp/FontSystemSettings.cs
+++ b/src/FontStashSharp/FontSystemSettings.cs
@@ -28,6 +28,9 @@ namespace FontStashSharp
 		private int _textureWidth = 1024, _textureHeight = 1024;
 		private float _fontResolutionFactor = 1.0f;
 		private int _kernelWidth = 0, _kernelHeight = 0;
+		private bool _useTextShaping = false;
+		private int _shapedTextCacheSize = 100;
+		private bool _enableBiDi = true;
 
 		public int TextureWidth
 		{
@@ -112,6 +115,17 @@ namespace FontStashSharp
 		public bool StbTrueTypeUseOldRasterizer { get; set; }
 
 		/// <summary>
+		/// Enable HarfBuzz text shaping for complex scripts (Arabic, Indic, emoji sequences, etc.)
+		/// When false, uses simple codepoint-to-glyph rendering
+		/// Default: false
+		/// </summary>
+		public bool UseTextShaping
+		{
+			get => _useTextShaping;
+			set => _useTextShaping = value;
+		}
+
+		/// <summary>
 		/// Use existing texture for storing glyphs
 		/// If this is set, then TextureWidth & TextureHeight are ignored
 		/// </summary>
@@ -127,6 +141,37 @@ namespace FontStashSharp
 		/// </summary>
 		public IFontLoader FontLoader { get; set; }
 
+		/// <summary>
+		/// Maximum number of entries in the shaped text cache (for HarfBuzz text shaping)
+		/// Higher values use more memory but reduce shaping overhead for repeated text
+		/// Default: 100
+		/// </summary>
+		public int ShapedTextCacheSize
+		{
+			get => _shapedTextCacheSize;
+			set
+			{
+				if (value < 1)
+				{
+					throw new ArgumentOutOfRangeException(nameof(value), value, "Cache size must be at least 1");
+				}
+
+				_shapedTextCacheSize = value;
+			}
+		}
+
+		/// <summary>
+		/// Enable bidirectional (BiDi) text support for mixed LTR/RTL text
+		/// When enabled, text with mixed Latin and RTL scripts (Arabic, Hebrew, etc.) will be displayed in correct order
+		/// Only applies when UseTextShaping is true
+		/// Default: true
+		/// </summary>
+		public bool EnableBiDi
+		{
+			get => _enableBiDi;
+			set => _enableBiDi = value;
+		}
+
 		public FontSystemSettings()
 		{
 			TextureWidth = FontSystemDefaults.TextureWidth;
@@ -137,6 +182,8 @@ namespace FontStashSharp
 			KernelHeight = FontSystemDefaults.KernelHeight;
 			StbTrueTypeUseOldRasterizer = FontSystemDefaults.StbTrueTypeUseOldRasterizer;
 			FontLoader = FontSystemDefaults.FontLoader;
+			ShapedTextCacheSize = FontSystemDefaults.ShapedTextCacheSize;
+			EnableBiDi = true;
 		}
 
 		public FontSystemSettings Clone()
@@ -151,9 +198,12 @@ namespace FontStashSharp
 				KernelWidth = KernelWidth,
 				KernelHeight = KernelHeight,
 				StbTrueTypeUseOldRasterizer = StbTrueTypeUseOldRasterizer,
+				UseTextShaping = UseTextShaping,
 				ExistingTexture = ExistingTexture,
 				ExistingTextureUsedSpace = ExistingTextureUsedSpace,
-				FontLoader = FontLoader
+				FontLoader = FontLoader,
+				ShapedTextCacheSize = ShapedTextCacheSize,
+				EnableBiDi = EnableBiDi
 			};
 		}
 	}

--- a/src/FontStashSharp/HarfBuzz/BiDiAnalyzer.cs
+++ b/src/FontStashSharp/HarfBuzz/BiDiAnalyzer.cs
@@ -1,0 +1,177 @@
+﻿using System.Collections.Generic;
+
+namespace FontStashSharp.HarfBuzz
+{
+	/// <summary>
+	/// Direction of text flow
+	/// </summary>
+	public enum TextDirection
+	{
+		/// <summary>
+		/// Left-to-right text (Latin, Cyrillic, etc.)
+		/// </summary>
+		LTR,
+
+		/// <summary>
+		/// Right-to-left text (Arabic, Hebrew, etc.)
+		/// </summary>
+		RTL
+	}
+
+	/// <summary>
+	/// Represents a segment of text with uniform directionality
+	/// </summary>
+	public struct DirectionalRun
+	{
+		/// <summary>
+		/// Start position in the original text
+		/// </summary>
+		public int Start;
+
+		/// <summary>
+		/// Length of the run
+		/// </summary>
+		public int Length;
+
+		/// <summary>
+		/// Direction of this run
+		/// </summary>
+		public TextDirection Direction;
+	}
+
+	/// <summary>
+	/// A simple bidirectional text analyzer for mixed LTR/RTL text
+	/// </summary>
+	public static class BiDiAnalyzer
+	{
+		/// <summary>
+		/// Segments text into runs of consistent directionality
+		/// </summary>
+		public static List<DirectionalRun> SegmentIntoDirectionalRuns(string text)
+		{
+			var runs = new List<DirectionalRun>();
+			int runStart = 0;
+			TextDirection? currentDirection = null;
+
+			for (int i = 0; i < text.Length; i++)
+			{
+				var charDirection = GetStrongDirection(text[i]);
+
+				// Skip neutral characters as they belong to the current run
+				if (charDirection == null)
+					continue;
+
+				// If direction changes, start a new run
+				if (currentDirection.HasValue && charDirection != currentDirection)
+				{
+					// Close the current run
+					runs.Add(new DirectionalRun
+					{
+						Start = runStart,
+						Length = i - runStart,
+						Direction = currentDirection.Value
+					});
+
+					runStart = i;
+					currentDirection = charDirection;
+				}
+				else if (!currentDirection.HasValue)
+				{
+					// First strong character - leading neutral characters become part of this run
+					currentDirection = charDirection;
+				}
+			}
+
+			// Add the final run
+			if (currentDirection.HasValue)
+			{
+				runs.Add(new DirectionalRun
+				{
+					Start = runStart,
+					Length = text.Length - runStart,
+					Direction = currentDirection.Value
+				});
+			}
+			else if (text.Length > runStart)
+			{
+				// Entire text is neutral - default to LTR
+				runs.Add(new DirectionalRun
+				{
+					Start = runStart,
+					Length = text.Length - runStart,
+					Direction = TextDirection.LTR
+				});
+			}
+
+			return runs;
+		}
+
+		/// <summary>
+		/// Checks if a character is right-to-left
+		/// </summary>
+		/// <remarks>https://www.ssec.wisc.edu/~tomw/java/unicode.html</remarks>
+		private static bool IsRTL(char c)
+		{
+			// Hebrew block (U+0590 to U+05FF)
+			if (c >= 0x0590 && c <= 0x05FF) return true;
+
+			// Arabic block (U+0600 to U+06FF)
+			if (c >= 0x0600 && c <= 0x06FF) return true;
+
+			// Syriac (U+0700 to U+074F)
+			if (c >= 0x0700 && c <= 0x074F) return true;
+
+			// Thaana (U+0780 to U+07BF)
+			if (c >= 0x0780 && c <= 0x07BF) return true;
+
+			// NKo (U+07C0 to U+07FF)
+			if (c >= 0x07C0 && c <= 0x07FF) return true;
+
+			// Samaritan (U+0800 to U+083F)
+			if (c >= 0x0800 && c <= 0x083F) return true;
+
+			// Mandaic (U+0840 to U+085F)
+			if (c >= 0x0840 && c <= 0x085F) return true;
+
+			// Arabic Extended-A (U+08A0 to U+08FF)
+			if (c >= 0x08A0 && c <= 0x08FF) return true;
+
+			// Hebrew presentation forms (U+FB1D to U+FB4F)
+			if (c >= 0xFB1D && c <= 0xFB4F) return true;
+
+			// Arabic presentation forms-A (U+FB50 to U+FDFF)
+			if (c >= 0xFB50 && c <= 0xFDFF) return true;
+
+			// Arabic presentation forms-B (U+FE70 to U+FEFC)
+			if (c >= 0xFE70 && c <= 0xFEFC) return true;
+
+			return false;
+		}
+
+		/// <summary>
+		/// Checks if a character is neutral (takes direction from context)
+		/// </summary>
+		private static bool IsNeutral(char c)
+		{
+			return char.IsWhiteSpace(c) ||
+						 char.IsPunctuation(c) ||
+						 char.IsSymbol(c) ||
+						 char.IsSeparator(c);
+		}
+
+		/// <summary>
+		/// Gets the strong directionality of a character
+		/// </summary>
+		private static TextDirection? GetStrongDirection(char c)
+		{
+			if (IsRTL(c))
+				return TextDirection.RTL;
+
+			// If not RTL and not neutral, assume LTR
+			if (!IsNeutral(c))
+				return TextDirection.LTR;
+
+			return null; // Neutral character
+		}
+	}
+}

--- a/src/FontStashSharp/HarfBuzz/HarfBuzzFont.cs
+++ b/src/FontStashSharp/HarfBuzz/HarfBuzzFont.cs
@@ -1,0 +1,74 @@
+﻿using System;
+using System.Runtime.InteropServices;
+using HarfBuzzSharp;
+
+namespace FontStashSharp.HarfBuzz
+{
+	/// <summary>
+	/// Wrapper for HarfBuzz font resources
+	/// </summary>
+	internal class HarfBuzzFont : IDisposable
+	{
+		private Blob _blob;
+		private Face _face;
+		private Font _font;
+		private GCHandle _fontDataHandle;
+		private int _currentScale = -1;
+
+		public Font Font => _font;
+
+		public HarfBuzzFont(byte[] fontData)
+		{
+			// Pin the byte array in memory
+			_fontDataHandle = GCHandle.Alloc(fontData, GCHandleType.Pinned);
+			var dataPtr = _fontDataHandle.AddrOfPinnedObject();
+
+			// Create HarfBuzz blob from font data
+			_blob = new Blob(dataPtr, fontData.Length, MemoryMode.ReadOnly);
+
+			// Create face from blob and font from face
+			_face = new Face(_blob, 0);
+			_font = new Font(_face);
+		}
+
+		/// <summary>
+		/// Set the font scale for a specific font size
+		/// </summary>
+		public void SetScale(float fontSize)
+		{
+			// Convert fontSize to font units
+			// Set scale to 26.6 fixed-point pixels (fontSize * 64)
+			// HarfBuzz will then output positions in 26.6 format directly
+			var scale = (int)(fontSize * 64);
+
+			// Skip if scale hasn't changed
+			if (_currentScale == scale)
+			{
+				return;
+			}
+
+			_currentScale = scale;
+			_font.SetScale(scale, scale);
+		}
+
+		/// <summary>
+		/// Shape text using this font
+		/// </summary>
+		public void Shape(HarfBuzzSharp.Buffer buffer)
+		{
+			_font.Shape(buffer);
+		}
+
+		public void Dispose()
+		{
+			_font?.Dispose();
+			_face?.Dispose();
+			_blob?.Dispose();
+
+			if (_fontDataHandle.IsAllocated)
+			{
+				_fontDataHandle.Free();
+			}
+		}
+	}
+}

--- a/src/FontStashSharp/HarfBuzz/ShapedText.cs
+++ b/src/FontStashSharp/HarfBuzz/ShapedText.cs
@@ -1,0 +1,64 @@
+﻿namespace FontStashSharp.HarfBuzz
+{
+	/// <summary>
+	/// Represents a single shaped glyph from HarfBuzz
+	/// </summary>
+	public class ShapedGlyph
+	{
+		/// <summary>
+		/// The glyph ID from the font
+		/// </summary>
+		public int GlyphId;
+
+		/// <summary>
+		/// The cluster index in the original text
+		/// </summary>
+		public int Cluster;
+
+		/// <summary>
+		/// Which font source this glyph is from (for font fallback)
+		/// </summary>
+		public int FontSourceIndex;
+
+		/// <summary>
+		/// Horizontal advance in font units
+		/// </summary>
+		public int XAdvance;
+
+		/// <summary>
+		/// Vertical advance in font units
+		/// </summary>
+		public int YAdvance;
+
+		/// <summary>
+		/// Horizontal offset in font units
+		/// </summary>
+		public int XOffset;
+
+		/// <summary>
+		/// Vertical offset in font units
+		/// </summary>
+		public int YOffset;
+	}
+
+	/// <summary>
+	/// Contains the result of HarfBuzz text shaping
+	/// </summary>
+	public class ShapedText
+	{
+		/// <summary>
+		/// The shaped glyphs in visual order
+		/// </summary>
+		public ShapedGlyph[] Glyphs;
+
+		/// <summary>
+		/// The original text that was shaped
+		/// </summary>
+		public string OriginalText;
+
+		/// <summary>
+		/// Font size used for shaping
+		/// </summary>
+		public float FontSize;
+	}
+}

--- a/src/FontStashSharp/HarfBuzz/TextShaper.cs
+++ b/src/FontStashSharp/HarfBuzz/TextShaper.cs
@@ -1,0 +1,179 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace FontStashSharp.HarfBuzz
+{
+	/// <summary>
+	/// Handles text shaping using HarfBuzz
+	/// </summary>
+	public static class TextShaper
+	{
+		/// <summary>
+		/// Shape text using HarfBuzz
+		/// </summary>
+		/// <param name="fontSystem">The font system containing font sources</param>
+		/// <param name="text">The text to shape</param>
+		/// <param name="fontSize">The font size</param>
+		/// <returns>Shaped text with glyph information</returns>
+		public static ShapedText Shape(FontSystem fontSystem, string text, float fontSize)
+		{
+			if (string.IsNullOrEmpty(text))
+			{
+				return new ShapedText
+				{
+					Glyphs = new ShapedGlyph[0],
+					OriginalText = text ?? string.Empty,
+					FontSize = fontSize
+				};
+			}
+
+			var allShapedGlyphs = new List<ShapedGlyph>(text.Length);
+
+			// Step 1: Analyze text for bidirectional runs (if enabled)
+			List<DirectionalRun> directionalRuns;
+			if (fontSystem.EnableBiDi)
+			{
+				directionalRuns = BiDiAnalyzer.SegmentIntoDirectionalRuns(text);
+			}
+			else
+			{
+				// BiDi disabled - treat entire text as single LTR run
+				directionalRuns = new List<DirectionalRun>
+				{
+					new DirectionalRun
+					{
+						Start = 0,
+						Length = text.Length,
+						Direction = TextDirection.LTR
+					}
+				};
+			}
+
+			// Step 2: Process each directional run
+			foreach (var dirRun in directionalRuns)
+			{
+				// Step 3: Within each directional run, segment by font source
+				var fontRuns = SegmentTextIntoFontRuns(fontSystem, text, dirRun.Start, dirRun.Length);
+
+				// Step 4: Shape each font run with its appropriate font
+				foreach (var fontRun in fontRuns)
+				{
+					var hbFont = fontSystem.GetHarfBuzzFont(fontRun.FontSourceIndex);
+
+					if (hbFont == null)
+					{
+						throw new InvalidOperationException($"HarfBuzz font not available for font source {fontRun.FontSourceIndex}. Ensure font data is cached.");
+					}
+
+					hbFont.SetScale(fontSize);
+
+					using (var buffer = new HarfBuzzSharp.Buffer())
+					{
+						// Add text run to buffer
+						buffer.AddUtf16(text, fontRun.Start, fontRun.Length);
+						buffer.GuessSegmentProperties();
+						hbFont.Shape(buffer);
+
+						// Get the shaped output
+						var glyphInfos = buffer.GlyphInfos;
+						var glyphPositions = buffer.GlyphPositions;
+
+						// Convert to our ShapedGlyph format
+						for (int i = 0; i < glyphInfos.Length; i++)
+						{
+							var info = glyphInfos[i];
+							var pos = glyphPositions[i];
+
+							allShapedGlyphs.Add(new ShapedGlyph
+							{
+								GlyphId = (int)info.Codepoint,
+								Cluster = (int)info.Cluster + fontRun.Start,
+								FontSourceIndex = fontRun.FontSourceIndex,
+								XAdvance = pos.XAdvance,
+								YAdvance = pos.YAdvance,
+								XOffset = pos.XOffset,
+								YOffset = pos.YOffset
+							});
+						}
+					}
+				}
+			}
+
+			return new ShapedText
+			{
+				Glyphs = allShapedGlyphs.ToArray(),
+				OriginalText = text,
+				FontSize = fontSize
+			};
+		}
+
+		private struct FontRun
+		{
+			public int Start;
+			public int Length;
+			public int FontSourceIndex;
+		}
+
+		private static List<FontRun> SegmentTextIntoFontRuns(FontSystem fontSystem, string text, int start, int length)
+		{
+			var runs = new List<FontRun>();
+			int currentRunStart = start;
+			int currentFontSourceIndex = -1;
+			int end = start + length;
+
+			for (int i = start; i < end;)
+			{
+				// Get the codepoint at position i
+				int codepoint;
+				int charCount;
+				if (i < text.Length - 1 && char.IsSurrogatePair(text, i))
+				{
+					codepoint = char.ConvertToUtf32(text, i);
+					charCount = 2;
+				}
+				else
+				{
+					codepoint = text[i];
+					charCount = 1;
+				}
+
+				// Find which font source has this codepoint
+				var glyphId = fontSystem.GetCodepointIndex(codepoint, out int fontSourceIndex);
+
+				// If this is a new font source, start a new run
+				if (fontSourceIndex != currentFontSourceIndex)
+				{
+					// Save the previous run if it exists
+					if (currentFontSourceIndex >= 0)
+					{
+						runs.Add(new FontRun
+						{
+							Start = currentRunStart,
+							Length = i - currentRunStart,
+							FontSourceIndex = currentFontSourceIndex
+						});
+					}
+
+					// Start new run
+					currentRunStart = i;
+					currentFontSourceIndex = fontSourceIndex;
+				}
+
+				i += charCount;
+			}
+
+			// Add the final run
+			if (currentFontSourceIndex >= 0)
+			{
+				runs.Add(new FontRun
+				{
+					Start = currentRunStart,
+					Length = end - currentRunStart,
+					FontSourceIndex = currentFontSourceIndex
+				});
+			}
+
+			return runs;
+		}
+	}
+}

--- a/src/FontStashSharp/SpriteFontBase.IFontStashRenderer2.cs
+++ b/src/FontStashSharp/SpriteFontBase.IFontStashRenderer2.cs
@@ -38,7 +38,7 @@ namespace FontStashSharp
 			var start = Vector2.Zero;
 			if (textStyle == TextStyle.Strikethrough)
 			{
-				start.Y = pos.Y - ascent  + lineHeight / 2 - (FontSystemDefaults.TextStyleLineHeight / 2) * RenderFontSizeMultiplicator;
+				start.Y = pos.Y - ascent + lineHeight / 2 - (FontSystemDefaults.TextStyleLineHeight / 2) * RenderFontSizeMultiplicator;
 			}
 			else
 			{
@@ -74,6 +74,13 @@ namespace FontStashSharp
 #endif
 
 			if (source.IsNull) return 0.0f;
+
+			var dynamicFont = this as DynamicSpriteFont;
+			if (dynamicFont != null && dynamicFont.FontSystem.UseTextShaping)
+			{
+				return DrawShapedText(renderer, source, position, rotation, origin, sourceScale,
+					layerDepth, characterSpacing, lineSpacing, textStyle, effect, effectAmount);
+			}
 
 			Matrix transformation;
 			var scale = sourceScale ?? Utility.DefaultScale;
@@ -156,6 +163,132 @@ namespace FontStashSharp
 			return position.X + position.X;
 		}
 
+		private float DrawShapedText(IFontStashRenderer2 renderer, TextColorSource source, Vector2 position,
+			float rotation, Vector2 origin, Vector2? sourceScale,
+			float layerDepth, float characterSpacing, float lineSpacing,
+			TextStyle textStyle, FontSystemEffect effect, int effectAmount)
+		{
+			var dynamicFont = this as DynamicSpriteFont;
+			if (dynamicFont == null)
+			{
+				throw new InvalidOperationException("Text shaping is only supported with DynamicSpriteFont");
+			}
+
+			var text = source.TextSource.StringText.String ?? source.TextSource.StringBuilderText?.ToString();
+			if (string.IsNullOrEmpty(text))
+			{
+				return 0.0f;
+			}
+
+			Matrix transformation;
+			var scale = sourceScale ?? Utility.DefaultScale;
+			Prepare(position, rotation, origin, ref scale, out transformation);
+
+			var lines = text.Split('\n');
+
+			int ascent = 0, lineHeight = 0;
+			if (dynamicFont.FontSystem.FontSources.Count > 0)
+			{
+				int descent, lh;
+				dynamicFont.FontSystem.FontSources[0].GetMetricsForSize(FontSize * dynamicFont.FontSystem.FontResolutionFactor, out ascent, out descent, out lh);
+				lineHeight = lh;
+			}
+
+			var pos = new Vector2(0, ascent);
+			float maxX = 0;
+			Color? firstColor = null;
+			var topLeft = new VertexPositionColorTexture();
+			var topRight = new VertexPositionColorTexture();
+			var bottomLeft = new VertexPositionColorTexture();
+			var bottomRight = new VertexPositionColorTexture();
+
+			for (int lineIndex = 0; lineIndex < lines.Length; lineIndex++)
+			{
+				var line = lines[lineIndex];
+
+				if (lineIndex > 0)
+				{
+					if (textStyle != TextStyle.None && firstColor != null)
+					{
+						RenderStyle(renderer, textStyle, pos,
+							lineHeight, ascent, firstColor.Value, ref transformation, layerDepth,
+							ref topLeft, ref topRight, ref bottomLeft, ref bottomRight);
+					}
+
+					pos.X = 0.0f;
+					pos.Y += lineHeight + lineSpacing;
+					firstColor = null;
+				}
+
+				if (string.IsNullOrEmpty(line))
+				{
+					continue;
+				}
+
+				var shapedText = dynamicFont.GetShapedText(line, FontSize * dynamicFont.FontSystem.FontResolutionFactor);
+
+				float lineStartX = pos.X;
+				for (int i = 0; i < shapedText.Glyphs.Length; i++)
+				{
+					var shapedGlyph = shapedText.Glyphs[i];
+
+					if (i > 0 && characterSpacing > 0)
+					{
+						pos.X += characterSpacing;
+					}
+
+#if MONOGAME || FNA || STRIDE
+					var glyph = dynamicFont.GetGlyphByGlyphId(renderer.GraphicsDevice, shapedGlyph.GlyphId, shapedGlyph.FontSourceIndex, effect, effectAmount);
+#else
+					var glyph = dynamicFont.GetGlyphByGlyphId(renderer.TextureManager, shapedGlyph.GlyphId, shapedGlyph.FontSourceIndex, effect, effectAmount);
+#endif
+
+					if (glyph != null && !glyph.IsEmpty)
+					{
+						var color = source.GetNextColor();
+						firstColor = color;
+
+						// Apply HarfBuzz positioning
+						var glyphPos = pos + new Vector2(
+							glyph.RenderOffset.X + (shapedGlyph.XOffset / 64.0f),
+							glyph.RenderOffset.Y + (shapedGlyph.YOffset / 64.0f)
+						);
+
+						var size = new Vector2(glyph.Size.X, glyph.Size.Y);
+						renderer.DrawQuad(glyph.Texture, color, glyphPos, ref transformation,
+							layerDepth, size, glyph.TextureRectangle,
+							ref topLeft, ref topRight, ref bottomLeft, ref bottomRight);
+					}
+
+					if (glyph != null)
+					{
+						pos.X += glyph.XAdvance;
+						pos.Y += (shapedGlyph.YAdvance / 64.0f);
+					}
+					else
+					{
+						// Fallback
+						pos.X += (shapedGlyph.XAdvance / 64.0f);
+						pos.Y += (shapedGlyph.YAdvance / 64.0f);
+					}
+				}
+
+				if (pos.X > maxX)
+				{
+					maxX = pos.X;
+				}
+			}
+
+			if (textStyle != TextStyle.None && firstColor != null)
+			{
+				RenderStyle(renderer, textStyle, pos,
+					lineHeight, ascent, firstColor.Value, ref transformation, layerDepth,
+					ref topLeft, ref topRight, ref bottomLeft, ref bottomRight);
+			}
+
+			return position.X + maxX;
+		}
+
 		/// <summary>
 		/// Draws a text
 		/// </summary>
@@ -170,7 +303,7 @@ namespace FontStashSharp
 		/// <param name="characterSpacing">A character spacing</param>
 		/// <param name="lineSpacing">A line spacing</param>
 		public float DrawText(IFontStashRenderer2 renderer, string text, Vector2 position, Color color,
-			float rotation = 0, Vector2 origin = default(Vector2), Vector2? scale = null, 
+			float rotation = 0, Vector2 origin = default(Vector2), Vector2? scale = null,
 			float layerDepth = 0.0f, float characterSpacing = 0.0f, float lineSpacing = 0.0f,
 			TextStyle textStyle = TextStyle.None, FontSystemEffect effect = FontSystemEffect.None, int effectAmount = 0) =>
 				DrawText(renderer, new TextColorSource(text, color), position, rotation, origin, scale, layerDepth,
@@ -190,7 +323,7 @@ namespace FontStashSharp
 		/// <param name="characterSpacing">A character spacing</param>
 		/// <param name="lineSpacing">A line spacing</param>
 		public float DrawText(IFontStashRenderer2 renderer, string text, Vector2 position, Color[] colors,
-			float rotation = 0, Vector2 origin = default(Vector2), Vector2? scale = null, 
+			float rotation = 0, Vector2 origin = default(Vector2), Vector2? scale = null,
 			float layerDepth = 0.0f, float characterSpacing = 0.0f, float lineSpacing = 0.0f,
 			TextStyle textStyle = TextStyle.None, FontSystemEffect effect = FontSystemEffect.None, int effectAmount = 0) =>
 				DrawText(renderer, new TextColorSource(text, colors), position, rotation, origin, scale, layerDepth,
@@ -210,7 +343,7 @@ namespace FontStashSharp
 		/// <param name="characterSpacing">A character spacing</param>
 		/// <param name="lineSpacing">A line spacing</param>
 		public float DrawText(IFontStashRenderer2 renderer, StringSegment text, Vector2 position, Color color,
-			float rotation = 0, Vector2 origin = default(Vector2), Vector2? scale = null, 
+			float rotation = 0, Vector2 origin = default(Vector2), Vector2? scale = null,
 			float layerDepth = 0.0f, float characterSpacing = 0.0f, float lineSpacing = 0.0f,
 			TextStyle textStyle = TextStyle.None, FontSystemEffect effect = FontSystemEffect.None, int effectAmount = 0) =>
 				DrawText(renderer, new TextColorSource(text, color), position, rotation, origin, scale, layerDepth,
@@ -230,7 +363,7 @@ namespace FontStashSharp
 		/// <param name="characterSpacing">A character spacing</param>
 		/// <param name="lineSpacing">A line spacing</param>
 		public float DrawText(IFontStashRenderer2 renderer, StringSegment text, Vector2 position, Color[] colors,
-			float rotation = 0, Vector2 origin = default(Vector2), Vector2? scale = null, 
+			float rotation = 0, Vector2 origin = default(Vector2), Vector2? scale = null,
 			float layerDepth = 0.0f, float characterSpacing = 0.0f, float lineSpacing = 0.0f,
 			TextStyle textStyle = TextStyle.None, FontSystemEffect effect = FontSystemEffect.None, int effectAmount = 0) =>
 				DrawText(renderer, new TextColorSource(text, colors), position, rotation, origin, scale, layerDepth,
@@ -250,7 +383,7 @@ namespace FontStashSharp
 		/// <param name="characterSpacing">A character spacing</param>
 		/// <param name="lineSpacing">A line spacing</param>
 		public float DrawText(IFontStashRenderer2 renderer, StringBuilder text, Vector2 position, Color color,
-			float rotation = 0, Vector2 origin = default(Vector2), Vector2? scale = null, 
+			float rotation = 0, Vector2 origin = default(Vector2), Vector2? scale = null,
 			float layerDepth = 0.0f, float characterSpacing = 0.0f, float lineSpacing = 0.0f,
 			TextStyle textStyle = TextStyle.None, FontSystemEffect effect = FontSystemEffect.None, int effectAmount = 0) =>
 				DrawText(renderer, new TextColorSource(text, color), position, rotation, origin, scale, layerDepth,
@@ -270,7 +403,7 @@ namespace FontStashSharp
 		/// <param name="characterSpacing">A character spacing</param>
 		/// <param name="lineSpacing">A line spacing</param>
 		public float DrawText(IFontStashRenderer2 renderer, StringBuilder text, Vector2 position, Color[] colors,
-			float rotation = 0, Vector2 origin = default(Vector2), Vector2? scale = null, 
+			float rotation = 0, Vector2 origin = default(Vector2), Vector2? scale = null,
 			float layerDepth = 0.0f, float characterSpacing = 0.0f, float lineSpacing = 0.0f,
 			TextStyle textStyle = TextStyle.None, FontSystemEffect effect = FontSystemEffect.None, int effectAmount = 0) =>
 				DrawText(renderer, new TextColorSource(text, colors), position, rotation, origin, scale, layerDepth,

--- a/src/XNA/FontStashSharp.MonoGame.csproj
+++ b/src/XNA/FontStashSharp.MonoGame.csproj
@@ -15,6 +15,7 @@
   <ItemGroup>
     <PackageReference Include="FontStashSharp.Base" Version="$(FontStashSharpBaseVersion)" />
     <PackageReference Include="FontStashSharp.Rasterizers.StbTrueTypeSharp" Version="$(FontStashSharpBaseVersion)" />
+    <PackageReference Include="HarfBuzzSharp" Version="8.3.1.2" />
     <PackageReference Include="MonoGame.Framework.DesktopGL" PrivateAssets="All" Version="$(MonoGameVersion)" />
     <PackageReference Include="Cyotek.Drawing.BitmapFont" Version="$(CyotekDrawingBitmapFontVersion)" />
     <PackageReference Include="StbImageSharp" Version="$(StbImageSharpVersion)" />


### PR DESCRIPTION
This PR adds optional text shaping to FSS using HarfBuzzSharp which allows for proper glyph substitution and positioning (for example complex emojis will display correctly 👨‍👩‍👧‍👦, and Arabic text will display correctly). Opt in via `FontSystemSettings.UseTextShaping = true`

Automatic detection and segmentation of mixed LTR/RTL text configurable via `FontSystemSettings.EnableBiDi`

There is an LRU-based cache for shaping configurable through `FontSystemSettings.ShapedTextCacheSize`

### Performance

####   Memory:
  - Each HarfBuzzFont wraps native resources (~few KB per font)
  - Shaped text cache stores results (configurable, default 100 entries)
  - GCHandle pins font data in memory (required for HarfBuzz)

####   CPU:
  - Text shaping overhead on first render (cached thereafter)
  - Cache hit avoids re-shaping
  - BiDi analysis is an O(n) scan

####   Recommendations:
  - Keep shaped text cache size proportional to unique strings displayed
  - Disable BiDi if only LTR text is used
  - Disable text shaping entirely for simple Latin-only applications




### Before/After:
<img width="1479" height="680" alt="image" src="https://github.com/user-attachments/assets/c155ca87-9e8c-4b76-9ad5-e20682508dec" />
