### PR TITLE
LayoutBuilder.cs: Fix Invalid Chunk splitting

### DIFF
--- a/src/FontStashSharp/RichText/LayoutBuilder.cs
+++ b/src/FontStashSharp/RichText/LayoutBuilder.cs
@@ -442,6 +442,11 @@ namespace FontStashSharp.RichText
 						r.Y = lastBreakMeasure.Value.Y;
 						r.EndIndex = i = lastBreakIndex;
 					}
+					else if (_stringBuilder.Length > 1 && char.IsHighSurrogate(_stringBuilder[_stringBuilder.Length - 2]))
+					{
+						r.EndIndex--;
+						i--;
+					}
 
 					break;
 				}


### PR DESCRIPTION
It may happen that, with an "fitting" remainingWidth, the GetNextChunk function will split just inbetween a high surrogate and the low surrogate.
Thus when rendering, a chunk may contain only a high Surrogate without a low surrogate following, and char.ConvertToUtf32 will throw an Exception during glyph rendering.
This change just detects that scenario and jumps back to before the High Surrogate.

Don't know if this fix is to your liking. If not please add other suggestions.